### PR TITLE
Fix concurrency and performance issues

### DIFF
--- a/src/main/java/com/mojang/datafixers/NamedChoiceFinder.java
+++ b/src/main/java/com/mojang/datafixers/NamedChoiceFinder.java
@@ -73,8 +73,8 @@ final class NamedChoiceFinder<FT> implements OpticFinder<FT> {
             }*/
             if (targetType instanceof TaggedChoice.TaggedChoiceType<?>) {
                 final TaggedChoice.TaggedChoiceType<?> choiceType = (TaggedChoice.TaggedChoiceType<?>) targetType;
-                if (choiceType.types().containsKey(name)) {
-                    final Type<?> elementType = choiceType.types().get(name);
+                final Type<?> elementType = choiceType.types().get(name);
+                if (elementType != null) {
                     if (!Objects.equals(type, elementType)) {
                         return Either.right(new Type.FieldNotFoundException(String.format("Type error for choice type \"%s\": expected type: %s, actual type: %s)", name, targetType, elementType)));
                     }

--- a/src/main/java/com/mojang/datafixers/functions/PointFree.java
+++ b/src/main/java/com/mojang/datafixers/functions/PointFree.java
@@ -16,7 +16,7 @@ public abstract class PointFree<T> {
     private Function<DynamicOps<?>, T> value;
 
     @SuppressWarnings("ConstantConditions")
-    public Function<DynamicOps<?>, T> evalCached() {
+    public synchronized Function<DynamicOps<?>, T> evalCached() {
         if (!initialized) {
             initialized = true;
             value = eval();

--- a/src/main/java/com/mojang/datafixers/functions/PointFree.java
+++ b/src/main/java/com/mojang/datafixers/functions/PointFree.java
@@ -11,15 +11,19 @@ import java.util.Optional;
 import java.util.function.Function;
 
 public abstract class PointFree<T> {
-    private boolean initialized;
+    private volatile boolean initialized;
     @Nullable
     private Function<DynamicOps<?>, T> value;
 
     @SuppressWarnings("ConstantConditions")
-    public synchronized Function<DynamicOps<?>, T> evalCached() {
+    public Function<DynamicOps<?>, T> evalCached() {
         if (!initialized) {
-            initialized = true;
-            value = eval();
+            synchronized (this) {
+                if (!initialized) {
+                    value = eval();
+                    initialized = true;
+                }
+            }
         }
         return value;
     }

--- a/src/main/java/com/mojang/datafixers/schemas/Schema.java
+++ b/src/main/java/com/mojang/datafixers/schemas/Schema.java
@@ -4,8 +4,6 @@ package com.mojang.datafixers.schemas;
 
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
-import it.unimi.dsi.fastutil.objects.Object2IntMap;
-import it.unimi.dsi.fastutil.objects.Object2IntOpenHashMap;
 import com.mojang.datafixers.DSL;
 import com.mojang.datafixers.DataFixUtils;
 import com.mojang.datafixers.types.Type;
@@ -14,6 +12,9 @@ import com.mojang.datafixers.types.families.TypeFamily;
 import com.mojang.datafixers.types.templates.RecursivePoint;
 import com.mojang.datafixers.types.templates.TaggedChoice;
 import com.mojang.datafixers.types.templates.TypeTemplate;
+import it.unimi.dsi.fastutil.objects.Object2IntMap;
+import it.unimi.dsi.fastutil.objects.Object2IntMaps;
+import it.unimi.dsi.fastutil.objects.Object2IntOpenHashMap;
 
 import java.util.List;
 import java.util.Map;
@@ -22,8 +23,8 @@ import java.util.function.Function;
 import java.util.function.Supplier;
 
 public class Schema {
-    protected final Object2IntMap<String> RECURSIVE_TYPES = new Object2IntOpenHashMap<>();
-    private final Map<String, Supplier<TypeTemplate>> TYPE_TEMPLATES = Maps.newHashMap();
+    protected final Object2IntMap<String> RECURSIVE_TYPES = Object2IntMaps.synchronize(new Object2IntOpenHashMap<>());
+    private final Map<String, Supplier<TypeTemplate>> TYPE_TEMPLATES = Maps.newConcurrentMap();
     private final Map<String, Type<?>> TYPES;
     private final int versionKey;
     private final String name;
@@ -39,25 +40,30 @@ public class Schema {
     }
 
     protected Map<String, Type<?>> buildTypes() {
-        final Map<String, Type<?>> types = Maps.newHashMap();
+        final Map<String, Type<?>> types = Maps.newConcurrentMap();
 
         final List<TypeTemplate> templates = Lists.newArrayList();
 
-        for (final Object2IntMap.Entry<String> entry : RECURSIVE_TYPES.object2IntEntrySet()) {
-            templates.add(DSL.check(entry.getKey(), entry.getIntValue(), getTemplate(entry.getKey())));
+        synchronized (RECURSIVE_TYPES) {
+            for (final Object2IntMap.Entry<String> entry : RECURSIVE_TYPES.object2IntEntrySet()) {
+                templates.add(DSL.check(entry.getKey(), entry.getIntValue(), getTemplate(entry.getKey())));
+            }
         }
 
         final TypeTemplate choice = templates.stream().reduce(DSL::or).get();
         final TypeFamily family = new RecursiveTypeFamily(name, choice);
 
-        for (final String name : TYPE_TEMPLATES.keySet()) {
-            final Type<?> type;
-            if (RECURSIVE_TYPES.containsKey(name)) {
-                type = family.apply(RECURSIVE_TYPES.getInt(name));
-            } else {
-                type = getTemplate(name).apply(family).apply(-1);
+        synchronized (TYPE_TEMPLATES) {
+            for (final String name : TYPE_TEMPLATES.keySet()) {
+                final Type<?> type;
+                int recurseId = RECURSIVE_TYPES.getOrDefault(name, -1);
+                if (recurseId != -1) {
+                    type = family.apply(recurseId);
+                } else {
+                    type = getTemplate(name).apply(family).apply(-1);
+                }
+                types.put(name, type);
             }
-            types.put(name, type);
         }
         return types;
     }
@@ -91,8 +97,9 @@ public class Schema {
     }
 
     public TypeTemplate id(final String name) {
-        if (RECURSIVE_TYPES.containsKey(name)) {
-            return DSL.id(RECURSIVE_TYPES.get(name));
+        int id = RECURSIVE_TYPES.getOrDefault(name, -1);
+        if (id != -1) {
+            return DSL.id(id);
         }
         return getTemplate(name);
     }
@@ -140,8 +147,10 @@ public class Schema {
     public void registerType(final boolean recursive, final DSL.TypeReference type, final Supplier<TypeTemplate> template) {
         TYPE_TEMPLATES.put(type.typeName(), template);
         // TODO: calculate recursiveness instead of hardcoding
-        if (recursive && !RECURSIVE_TYPES.containsKey(type.typeName())) {
-            RECURSIVE_TYPES.put(type.typeName(), RECURSIVE_TYPES.size());
+        synchronized (RECURSIVE_TYPES) {
+            if (recursive && !RECURSIVE_TYPES.containsKey(type.typeName())) {
+                RECURSIVE_TYPES.put(type.typeName(), RECURSIVE_TYPES.size());
+            }
         }
     }
 

--- a/src/main/java/com/mojang/datafixers/schemas/Schema.java
+++ b/src/main/java/com/mojang/datafixers/schemas/Schema.java
@@ -52,7 +52,7 @@ public class Schema {
 
         for (final String name : TYPE_TEMPLATES.keySet()) {
             final Type<?> type;
-            int recurseId = RECURSIVE_TYPES.getOrDefault(name, -1);
+            final int recurseId = RECURSIVE_TYPES.getOrDefault(name, -1);
             if (recurseId != -1) {
                 type = family.apply(recurseId);
             } else {
@@ -92,7 +92,7 @@ public class Schema {
     }
 
     public TypeTemplate id(final String name) {
-        int id = RECURSIVE_TYPES.getOrDefault(name, -1);
+        final int id = RECURSIVE_TYPES.getOrDefault(name, -1);
         if (id != -1) {
             return DSL.id(id);
         }

--- a/src/main/java/com/mojang/datafixers/types/DynamicOps.java
+++ b/src/main/java/com/mojang/datafixers/types/DynamicOps.java
@@ -152,10 +152,7 @@ public interface DynamicOps<T> {
     }
 
     default Optional<T> getGeneric(final T input, final T key) {
-        return getMapValues(input).flatMap(map -> {
-            T value = map.get(key);
-            return value != null ? Optional.of(value) : Optional.empty();
-        });
+        return getMapValues(input).flatMap(map -> Optional.ofNullable(map.get(key)));
     }
 
     default T set(final T input, final String key, final T value) {

--- a/src/main/java/com/mojang/datafixers/types/DynamicOps.java
+++ b/src/main/java/com/mojang/datafixers/types/DynamicOps.java
@@ -153,10 +153,8 @@ public interface DynamicOps<T> {
 
     default Optional<T> getGeneric(final T input, final T key) {
         return getMapValues(input).flatMap(map -> {
-            if (map.containsKey(key)) {
-                return Optional.of(map.get(key));
-            }
-            return Optional.empty();
+            T value = map.get(key);
+            return value != null ? Optional.of(value) : Optional.empty();
         });
     }
 

--- a/src/main/java/com/mojang/datafixers/types/Type.java
+++ b/src/main/java/com/mojang/datafixers/types/Type.java
@@ -23,7 +23,6 @@ import com.mojang.datafixers.kinds.K1;
 import com.mojang.datafixers.types.families.RecursiveTypeFamily;
 import com.mojang.datafixers.types.templates.TaggedChoice;
 import com.mojang.datafixers.types.templates.TypeTemplate;
-import org.apache.commons.lang3.tuple.Triple;
 
 import javax.annotation.Nullable;
 import java.util.Map;

--- a/src/main/java/com/mojang/datafixers/types/Type.java
+++ b/src/main/java/com/mojang/datafixers/types/Type.java
@@ -162,13 +162,13 @@ public abstract class Type<A> implements App<Type.Mu, A> {
         // This code under contention would generate multiple rewrites, so we use CompletableFuture for pending rewrites.
         // We can not use computeIfAbsent because this is a recursive call that will block server startup
         // during the Bootstrap phrase that's trying to pre cache these rewrites.
-        Optional<? extends RewriteResult<?, ?>> rewrite = REWRITE_CACHE.get(key);
+        final Optional<? extends RewriteResult<?, ?>> rewrite = REWRITE_CACHE.get(key);
         //noinspection OptionalAssignedToNull
         if (rewrite != null) {
             return (Optional<RewriteResult<A, ?>>) rewrite;
         }
         CompletableFuture<Optional<? extends RewriteResult<?, ?>>> pending;
-        boolean needsCreate;
+        final boolean needsCreate;
         synchronized (PENDING_REWRITE_CACHE) {
             pending = PENDING_REWRITE_CACHE.get(key);
             needsCreate = pending == null;

--- a/src/main/java/com/mojang/datafixers/types/Type.java
+++ b/src/main/java/com/mojang/datafixers/types/Type.java
@@ -32,8 +32,8 @@ import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 
 public abstract class Type<A> implements App<Type.Mu, A> {
-    private static final Map<Triple<Type<?>, TypeRewriteRule, PointFreeRule>, CompletableFuture<Optional<? extends RewriteResult<?, ?>>>> PENDING_REWRITE_CACHE = Maps.newConcurrentMap();
-    private static final Map<Triple<Type<?>, TypeRewriteRule, PointFreeRule>, Optional<? extends RewriteResult<?, ?>>> REWRITE_CACHE = Maps.newConcurrentMap();
+    private final Map<Pair<TypeRewriteRule, PointFreeRule>, CompletableFuture<Optional<? extends RewriteResult<A, ?>>>> PENDING_REWRITE_CACHE = Maps.newConcurrentMap();
+    private final Map<Pair<TypeRewriteRule, PointFreeRule>, Optional<RewriteResult<A, ?>>> REWRITE_CACHE = Maps.newConcurrentMap();
 
     public static class Mu implements K1 {}
 
@@ -158,16 +158,16 @@ public abstract class Type<A> implements App<Type.Mu, A> {
 
     @SuppressWarnings("unchecked")
     public Optional<RewriteResult<A, ?>> rewrite(final TypeRewriteRule rule, final PointFreeRule fRule) {
-        final Triple<Type<?>, TypeRewriteRule, PointFreeRule> key = Triple.of(this, rule, fRule);
+        final Pair<TypeRewriteRule, PointFreeRule> key = Pair.of(rule, fRule);
         // This code under contention would generate multiple rewrites, so we use CompletableFuture for pending rewrites.
         // We can not use computeIfAbsent because this is a recursive call that will block server startup
         // during the Bootstrap phrase that's trying to pre cache these rewrites.
-        Optional<? extends RewriteResult<?, ?>> rewrite = REWRITE_CACHE.get(key);
+        Optional<RewriteResult<A, ?>> rewrite = REWRITE_CACHE.get(key);
         //noinspection OptionalAssignedToNull
         if (rewrite != null) {
-            return (Optional<RewriteResult<A, ?>>) rewrite;
+            return rewrite;
         }
-        CompletableFuture<Optional<? extends RewriteResult<?, ?>>> pending;
+        CompletableFuture<Optional<? extends RewriteResult<A, ?>>> pending;
         boolean needsCreate;
         synchronized (PENDING_REWRITE_CACHE) {
             pending = PENDING_REWRITE_CACHE.get(key);

--- a/src/main/java/com/mojang/datafixers/types/families/RecursiveTypeFamily.java
+++ b/src/main/java/com/mojang/datafixers/types/families/RecursiveTypeFamily.java
@@ -19,6 +19,7 @@ import com.mojang.datafixers.types.templates.RecursivePoint;
 import com.mojang.datafixers.types.templates.TypeTemplate;
 import com.mojang.datafixers.util.Either;
 import it.unimi.dsi.fastutil.ints.Int2ObjectMap;
+import it.unimi.dsi.fastutil.ints.Int2ObjectMaps;
 import it.unimi.dsi.fastutil.ints.Int2ObjectOpenHashMap;
 
 import javax.annotation.Nullable;
@@ -34,7 +35,7 @@ public final class RecursiveTypeFamily implements TypeFamily {
     private final TypeTemplate template;
     private final int size;
 
-    private final Int2ObjectMap<RecursivePoint.RecursivePointType<?>> types = new Int2ObjectOpenHashMap<>();
+    private final Int2ObjectMap<RecursivePoint.RecursivePointType<?>> types = Int2ObjectMaps.synchronize(new Int2ObjectOpenHashMap<>());
     private final int hashCode;
 
     public RecursiveTypeFamily(final String name, final TypeTemplate template) {

--- a/src/main/java/com/mojang/datafixers/types/templates/Tag.java
+++ b/src/main/java/com/mojang/datafixers/types/templates/Tag.java
@@ -175,8 +175,8 @@ public final class Tag implements TypeTemplate {
         public <T> Pair<T, Optional<A>> read(final DynamicOps<T> ops, final T input) {
             final Optional<Map<T, T>> map = ops.getMapValues(input);
             final T nameObject = ops.createString(name);
-            if (map.isPresent() && map.get().containsKey(nameObject)) {
-                final T elementValue = map.get().get(nameObject);
+            final T elementValue;
+            if (map.isPresent() && (elementValue = map.get().get(nameObject)) != null) {
                 final Optional<A> value = element.read(ops, elementValue).getSecond();
                 if (value.isPresent()) {
                     return Pair.of(ops.createMap(map.get().entrySet().stream().filter(e -> !Objects.equals(e.getKey(), nameObject)).collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue))), value);

--- a/src/main/java/com/mojang/datafixers/types/templates/TaggedChoice.java
+++ b/src/main/java/com/mojang/datafixers/types/templates/TaggedChoice.java
@@ -189,12 +189,12 @@ public final class TaggedChoice<K> implements TypeTemplate {
             if (values.isPresent()) {
                 final Map<T, T> map = values.get();
                 final T nameObject = ops.createString(name);
-                T mapValue = map.get(nameObject);
+                final T mapValue = map.get(nameObject);
                 if (mapValue != null) {
                     final Optional<K> key = keyType.read(ops, mapValue).getSecond();
                     //noinspection OptionalIsPresent
-                    K keyValue = key.isPresent() ? key.get() : null;
-                    Type<?> type = keyValue != null ? types.get(keyValue) : null;
+                    final K keyValue = key.isPresent() ? key.get() : null;
+                    final Type<?> type = keyValue != null ? types.get(keyValue) : null;
                     if (type == null) {
                         if (DataFixerUpper.ERRORS_ARE_FATAL) {
                             throw new IllegalArgumentException("Unsupported key: " + keyValue + " in " + this);


### PR DESCRIPTION
When implementing asynchronous chunk loading, numerous concurrency issues were found.

These changes have been in use in [Paper's Async Chunk](https://github.com/PaperMC/Paper/blob/468a1cbbd78384f2c728ef93d5f796d8b9891a7e/Spigot-Server-Patches/0375-Async-Chunk-Loading-and-Generation.patch) system now and have no more known issues. We are doing chunk conversions over the thread pool now.

Also replaced quite a few bad uses of Map.containsKey

containsKey "reads" cleaner, but results in double the performance cost of all map operations as containsKey in MOST cases where null values are not used is identical to get() == null

Considering how deep data fixers go in call stacks, with tons of map lookups, this micro optimization could provide some real gains.

Additionally, many of the containsKey/get/put style operations were also a concurrency risk, resulting in multiple computation/insertions.