### PR TITLE
Add GitHub meta files for contributing policy and Code of Conduct.

### DIFF
--- a/.github/CODE_OF_CONDUCT.md
+++ b/.github/CODE_OF_CONDUCT.md
@@ -1,0 +1,5 @@
+# Code of Conduct
+
+This project has adopted the [Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct/).
+For more information see the [Code of Conduct FAQ](https://opensource.microsoft.com/codeofconduct/faq/) or
+contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any additional questions or comments.

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -1,0 +1,6 @@
+# Contributing
+
+Contributions are welcome!
+
+Most contributions will require you to agree to a Contributor License Agreement (CLA) declaring that you have the right to,
+and actually do, grant us the rights to use your contribution. For details, visit https://cla.microsoft.com.


### PR DESCRIPTION
This PR adds GitHub meta files for the contributing policy and code of conduct. The information for these meta files has been copied from the README file of the project. You can find more information, and test this PR by checking [here](https://github.com/Mojang/DataFixerUpper/community).