### PR TITLE
Double Stream utils

### DIFF
--- a/src/main/java/com/mojang/serialization/Codec.java
+++ b/src/main/java/com/mojang/serialization/Codec.java
@@ -27,6 +27,7 @@ import java.util.function.Function;
 import java.util.function.Supplier;
 import java.util.function.UnaryOperator;
 import java.util.stream.Collectors;
+import java.util.stream.DoubleStream;
 import java.util.stream.IntStream;
 import java.util.stream.LongStream;
 import java.util.stream.Stream;
@@ -571,6 +572,24 @@ public interface Codec<A> extends Encoder<A>, Decoder<A> {
         @Override
         public String toString() {
             return "LongStream";
+        }
+    };
+
+    PrimitiveCodec<DoubleStream> DOUBLE_STREAM = new PrimitiveCodec<DoubleStream>() {
+        @Override
+        public <T> DataResult<DoubleStream> read(final DynamicOps<T> ops, final T input) {
+            return ops
+                    .getDoubleStream(input);
+        }
+
+        @Override
+        public <T> T write(final DynamicOps<T> ops, final DoubleStream value) {
+            return ops.createDoubleList(value);
+        }
+
+        @Override
+        public String toString() {
+            return "DoubleStream";
         }
     };
 

--- a/src/main/java/com/mojang/serialization/Dynamic.java
+++ b/src/main/java/com/mojang/serialization/Dynamic.java
@@ -11,6 +11,7 @@ import java.nio.ByteBuffer;
 import java.util.Map;
 import java.util.Objects;
 import java.util.function.Function;
+import java.util.stream.DoubleStream;
 import java.util.stream.IntStream;
 import java.util.stream.LongStream;
 import java.util.stream.Stream;
@@ -106,6 +107,11 @@ public class Dynamic<T> extends DynamicLike<T> {
     @Override
     public DataResult<LongStream> asLongStreamOpt() {
         return ops.getLongStream(value);
+    }
+
+    @Override
+    public DataResult<DoubleStream> asDoubleStreamOpt() {
+        return ops.getDoubleStream(value);
     }
 
     @Override

--- a/src/main/java/com/mojang/serialization/DynamicLike.java
+++ b/src/main/java/com/mojang/serialization/DynamicLike.java
@@ -15,6 +15,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.function.Function;
 import java.util.stream.Collectors;
+import java.util.stream.DoubleStream;
 import java.util.stream.IntStream;
 import java.util.stream.LongStream;
 import java.util.stream.Stream;
@@ -38,6 +39,7 @@ public abstract class DynamicLike<T> {
     public abstract DataResult<ByteBuffer> asByteBufferOpt();
     public abstract DataResult<IntStream> asIntStreamOpt();
     public abstract DataResult<LongStream> asLongStreamOpt();
+    public abstract DataResult<DoubleStream> asDoubleStreamOpt();
     public abstract OptionalDynamic<T> get(String key);
     public abstract DataResult<T> getGeneric(T key);
     public abstract DataResult<T> getElement(String key);
@@ -148,6 +150,10 @@ public abstract class DynamicLike<T> {
         return asLongStreamOpt().result().orElseGet(LongStream::empty);
     }
 
+    public DoubleStream asDoubleStream() {
+        return asDoubleStreamOpt().result().orElseGet(DoubleStream::empty);
+    }
+
     public <U> List<U> asList(final Function<Dynamic<T>, U> deserializer) {
         return asListOpt(deserializer).result().orElseGet(ImmutableList::of);
     }
@@ -230,5 +236,9 @@ public abstract class DynamicLike<T> {
 
     public Dynamic<?> createLongList(final LongStream input) {
         return new Dynamic<>(ops, ops.createLongList(input));
+    }
+
+    public Dynamic<?> createDoubleList(final DoubleStream input) {
+        return new Dynamic<>(ops, ops.createDoubleList(input));
     }
 }

--- a/src/main/java/com/mojang/serialization/DynamicOps.java
+++ b/src/main/java/com/mojang/serialization/DynamicOps.java
@@ -15,6 +15,7 @@ import java.util.function.BiConsumer;
 import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.stream.Collectors;
+import java.util.stream.DoubleStream;
 import java.util.stream.IntStream;
 import java.util.stream.LongStream;
 import java.util.stream.Stream;
@@ -193,6 +194,20 @@ public interface DynamicOps<T> {
 
     default T createLongList(final LongStream input) {
         return createList(input.mapToObj(this::createLong));
+    }
+
+    default DataResult<DoubleStream> getDoubleStream(final T input) {
+        return getStream(input).flatMap(stream -> {
+            final List<T> list = stream.collect(Collectors.toList());
+            if (list.stream().allMatch(element -> getNumberValue(element).result().isPresent())) {
+                return DataResult.success(list.stream().mapToDouble(element -> getNumberValue(element).result().get().doubleValue()));
+            }
+            return DataResult.error("Some elements are not doubles: " + input);
+        });
+    }
+
+    default T createDoubleList(final DoubleStream input) {
+        return createList(input.mapToObj(this::createDouble));
     }
 
     T remove(T input, String key);

--- a/src/main/java/com/mojang/serialization/OptionalDynamic.java
+++ b/src/main/java/com/mojang/serialization/OptionalDynamic.java
@@ -7,6 +7,7 @@ import com.mojang.datafixers.util.Pair;
 import java.nio.ByteBuffer;
 import java.util.Optional;
 import java.util.function.Function;
+import java.util.stream.DoubleStream;
 import java.util.stream.IntStream;
 import java.util.stream.LongStream;
 import java.util.stream.Stream;
@@ -69,6 +70,11 @@ public final class OptionalDynamic<T> extends DynamicLike<T> {
     @Override
     public DataResult<LongStream> asLongStreamOpt() {
         return flatMap(DynamicLike::asLongStreamOpt);
+    }
+
+    @Override
+    public DataResult<DoubleStream> asDoubleStreamOpt() {
+        return flatMap(DynamicLike::asDoubleStreamOpt);
     }
 
     @Override


### PR DESCRIPTION
This PR adds a util in `DynamicOps` allowing for a `DoubleStream` to be created from an input, and a util for a list to be created from a `DoubleStream`. These are direct copies of the existing variants for long and int streams.