### PR TITLE
Fix Dynamic.convert() turning Gson boolean primitives into false

### DIFF
--- a/src/main/java/com/mojang/datafixers/Dynamic.java
+++ b/src/main/java/com/mojang/datafixers/Dynamic.java
@@ -213,7 +213,7 @@ public class Dynamic<T> extends DynamicLike<T> {
             return outOps.createDouble(inOps.getNumberValue(input, 0).doubleValue());
         }
         if (Objects.equals(type, DSL.bool())) {
-            return outOps.createBoolean(inOps.getNumberValue(input, 0).byteValue() != 0);
+            return outOps.createBoolean(inOps.getBooleanValue(input).orElse(false));
         }
         if (Objects.equals(type, DSL.string())) {
             return outOps.createString(inOps.getStringValue(input).orElse(""));

--- a/src/main/java/com/mojang/datafixers/types/DynamicOps.java
+++ b/src/main/java/com/mojang/datafixers/types/DynamicOps.java
@@ -67,6 +67,10 @@ public interface DynamicOps<T> {
         return createNumeric(value);
     }
 
+    default Optional<Boolean> getBooleanValue(final T input) {
+        return getNumberValue(input).map(number -> number.byteValue() != 0);
+    }
+
     default T createBoolean(final boolean value) {
         return createByte((byte) (value ? 1 : 0));
     }

--- a/src/main/java/com/mojang/datafixers/types/JsonOps.java
+++ b/src/main/java/com/mojang/datafixers/types/JsonOps.java
@@ -88,8 +88,12 @@ public class JsonOps implements DynamicOps<JsonElement> {
 
     @Override
     public Optional<Boolean> getBooleanValue(final JsonElement input) {
-        if (input.isJsonPrimitive() && input.getAsJsonPrimitive().isBoolean()) {
-            return Optional.of(input.getAsBoolean());
+        if (input.isJsonPrimitive()) {
+            if (input.getAsJsonPrimitive().isBoolean()) {
+                return Optional.of(input.getAsBoolean());
+            } else if (input.getAsJsonPrimitive().isNumber()) {
+                return Optional.of(input.getAsNumber().byteValue() != 0);
+            }
         }
         return Optional.empty();
     }

--- a/src/main/java/com/mojang/datafixers/types/JsonOps.java
+++ b/src/main/java/com/mojang/datafixers/types/JsonOps.java
@@ -87,6 +87,14 @@ public class JsonOps implements DynamicOps<JsonElement> {
     }
 
     @Override
+    public Optional<Boolean> getBooleanValue(final JsonElement input) {
+        if (input.isJsonPrimitive() && input.getAsJsonPrimitive().isBoolean()) {
+            return Optional.of(input.getAsBoolean());
+        }
+        return Optional.empty();
+    }
+
+    @Override
     public JsonElement createBoolean(final boolean value) {
         return new JsonPrimitive(value);
     }

--- a/src/main/java/com/mojang/datafixers/types/JsonOps.java
+++ b/src/main/java/com/mojang/datafixers/types/JsonOps.java
@@ -71,8 +71,12 @@ public class JsonOps implements DynamicOps<JsonElement> {
 
     @Override
     public Optional<Number> getNumberValue(final JsonElement input) {
-        if (input.isJsonPrimitive() && input.getAsJsonPrimitive().isNumber()) {
-            return Optional.of(input.getAsNumber());
+        if (input.isJsonPrimitive()) {
+            if (input.getAsJsonPrimitive().isNumber()) {
+                return Optional.of(input.getAsNumber());
+            } else if (input.getAsJsonPrimitive().isBoolean()) {
+                return Optional.of(input.getAsBoolean() ? 1 : 0);
+            }
         }
         return Optional.empty();
     }


### PR DESCRIPTION
Dynamic.convert() checks the number values of the types that are converted, but JsonOps didn't provide a number value for booleans. convert() defaults to 0 (false), so Gson booleans were always false.

Edit: Here's an example of the behavior:
```java
// Different instances so convert() doesn't no-op
JsonOps ops1 = new JsonOps() {};
JsonOps ops2 = new JsonOps() {};
JsonElement converted = Dynamic.convert(ops1, ops2, new JsonPrimitive(true));
System.out.println(converted);
// prints false
```