### PR TITLE
Rename Codec.withDefault methods that accept a Supplier

### DIFF
--- a/src/main/java/com/mojang/serialization/Codec.java
+++ b/src/main/java/com/mojang/serialization/Codec.java
@@ -247,11 +247,11 @@ public interface Codec<A> extends Encoder<A>, Decoder<A> {
         });
     }
 
-    default Codec<A> withDefault(final Consumer<String> onError, final Supplier<? extends A> value) {
-        return withDefault(DataFixUtils.consumerToFunction(onError), value);
+    default Codec<A> withDefaultFrom(final Consumer<String> onError, final Supplier<? extends A> value) {
+        return withDefaultFrom(DataFixUtils.consumerToFunction(onError), value);
     }
 
-    default Codec<A> withDefault(final UnaryOperator<String> onError, final Supplier<? extends A> value) {
+    default Codec<A> withDefaultFrom(final UnaryOperator<String> onError, final Supplier<? extends A> value) {
         return mapResult(new ResultFunction<A>() {
             @Override
             public <T> DataResult<Pair<A, T>> apply(final DynamicOps<T> ops, final T input, final DataResult<Pair<A, T>> a) {
@@ -289,7 +289,7 @@ public interface Codec<A> extends Encoder<A>, Decoder<A> {
         });
     }
 
-    default Codec<A> withDefault(final Supplier<? extends A> value) {
+    default Codec<A> withDefaultFrom(final Supplier<? extends A> value) {
         return mapResult(new ResultFunction<A>() {
             @Override
             public <T> DataResult<Pair<A, T>> apply(final DynamicOps<T> ops, final T input, final DataResult<Pair<A, T>> a) {


### PR DESCRIPTION
Rename `Codec.withDefault` methods that accept a Supplier to `Codec.withDefaultFrom` to avoid a method conflict when implementing a `Codec<Supplier<T>>`.

Without this change, a `Codec<Supplier<T>>` results in `withDefault(Supplier<T>)` and `withDefault(Supplier<? extends Supplier<T>>)`.