### PR TITLE
Improve Error Messages for EitherCodec and EitherMapCodec

### DIFF
--- a/src/main/java/com/mojang/serialization/codecs/EitherCodec.java
+++ b/src/main/java/com/mojang/serialization/codecs/EitherCodec.java
@@ -25,7 +25,11 @@ public final class EitherCodec<F, S> implements Codec<Either<F, S>> {
         if (firstRead.result().isPresent()) {
             return firstRead;
         }
-        return second.decode(ops, input).map(vo -> vo.mapFirst(Either::right));
+        final DataResult<Pair<Either<F, S>, T>> secondRead = second.decode(ops, input).map(vo -> vo.mapFirst(Either::right));
+        if (secondRead.result().isPresent()) {
+            return secondRead;
+        }
+        return firstRead.mapError(err -> secondRead.error().map(pr -> "Either [" + err + "; " + pr.message() + "]").orElse(err));
     }
 
     @Override

--- a/src/main/java/com/mojang/serialization/codecs/EitherMapCodec.java
+++ b/src/main/java/com/mojang/serialization/codecs/EitherMapCodec.java
@@ -27,7 +27,11 @@ public final class EitherMapCodec<F, S> extends MapCodec<Either<F, S>> {
         if (firstRead.result().isPresent()) {
             return firstRead;
         }
-        return second.decode(ops, input).map(Either::right);
+        final DataResult<Either<F, S>> secondRead = second.decode(ops, input).map(Either::right);
+        if (secondRead.result().isPresent()) {
+            return secondRead;
+        }
+        return firstRead.mapError(err -> secondRead.error().map(pr -> "Either [" + err + "; " + pr.message() + "]").orElse(err));
     }
 
     @Override

--- a/src/test/java/com/mojang/serialization/EitherErrorReportingTest.java
+++ b/src/test/java/com/mojang/serialization/EitherErrorReportingTest.java
@@ -1,0 +1,77 @@
+package com.mojang.serialization;
+
+import com.mojang.datafixers.util.Either;
+import com.mojang.serialization.codecs.RecordCodecBuilder;
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+public class EitherErrorReportingTest
+{
+    private static class TestData {
+        private static final Codec<TestData> CODEC = RecordCodecBuilder.create(instance -> instance.group(
+            Codec.INT.fieldOf("x").forGetter(c -> c.x)
+        ).apply(instance, TestData::new));
+
+        private final int x;
+
+        private TestData(final int x) {
+            this.x = x;
+        }
+
+        @Override
+        public boolean equals(final Object o) {
+            if (this == o) {
+                return true;
+            }
+            if (o == null || getClass() != o.getClass()) {
+                return false;
+            }
+            final TestData testData = (TestData) o;
+            return x == testData.x;
+        }
+
+        @Override
+        public int hashCode() {
+            return x;
+        }
+    }
+
+    @Test
+    public void testEitherErrorNormal() {
+        testEitherError(JsonOps.INSTANCE);
+    }
+
+    @Test
+    public void testEitherErrorCompressed() {
+        testEitherError(JsonOps.COMPRESSED);
+    }
+
+    @Test
+    public void testEitherErrorSwappedNormal() {
+        testEitherErrorSwapped(JsonOps.INSTANCE);
+    }
+
+    @Test
+    public void testEitherErrorSwappedCompressed() {
+        testEitherErrorSwapped(JsonOps.COMPRESSED);
+    }
+
+    private static <T> void testEitherError(final DynamicOps<T> ops) {
+        final Codec<Either<Integer, TestData>> codec = Codec.either(Codec.intRange(0, 10), TestData.CODEC);
+        final T invalidData = ops.createInt(15);
+        final DataResult<Either<Integer, TestData>> result = codec.parse(ops, invalidData);
+
+        assertTrue(result.error().isPresent());
+        System.out.println(result.error().get().message());
+    }
+
+    private static <T> void testEitherErrorSwapped(final DynamicOps<T> ops) {
+        final Codec<Either<TestData, Integer>> codec = Codec.either(TestData.CODEC, Codec.intRange(0, 10));
+        final T invalidData = ops.createInt(15);
+        final DataResult<Either<TestData, Integer>> result = codec.parse(ops, invalidData);
+
+        assertTrue(result.error().isPresent());
+        System.out.println(result.error().get().message());
+    }
+}

--- a/src/test/java/com/mojang/serialization/EitherErrorReportingTest.java
+++ b/src/test/java/com/mojang/serialization/EitherErrorReportingTest.java
@@ -1,3 +1,5 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license.
 package com.mojang.serialization;
 
 import java.util.stream.Stream;
@@ -11,8 +13,7 @@ import org.junit.Test;
 
 import static org.junit.Assert.*;
 
-public class EitherErrorReportingTest
-{
+public class EitherErrorReportingTest {
     private static class TestData {
         private static final Codec<TestData> CODEC = RecordCodecBuilder.create(instance -> instance.group(
             Codec.INT.fieldOf("x").forGetter(c -> c.x)


### PR DESCRIPTION
### Problem

If an error occurs during decoding using an `EitherCodec` or `EitherMapCodec`, the error message will only include the message from the second `Codec`, and will make no mention of the fact this is an `Either` codec. This can lead to cases of *very* misleading errors, such as the infamous "Not a JSON Object" error, when in actuality, it was due to an `EitherCodec`'s message only including the second error and not mentioning the fact that an `Either` is involved.

### Solution

`EitherCodec` and `EitherMapCodec` were modified to concatenate both error messages, and clearly label them as due to an `Either`.

### Examples

Below are the errors that are reported with no changes to `EitherCodec` or `EitherMapCodec`, from the examples listed in `EitherErrorReportingTest`:

```
Not a JSON object: 15
Value 15 outside of range [0:10]
No key value in MapLike[{"data":"oops"}]
No key data in MapLike[{"value":15}]
Value 15 outside of range [0:10]
Not a JSON object: "oops"
```

And here are the same errors, after applying my changes:

```
Either [Not a JSON object: 15; Value 15 outside of range [0:10]]
Either [Value 15 outside of range [0:10]; No key data in MapLike[{"value":15}]]
Either [No key data in MapLike[{"value":15}]; Value 15 outside of range [0:10]]
Either [Not a JSON object: "oops"; No key value in MapLike[{"data":"oops"}]]
Either [No key value in MapLike[{"data":"oops"}]; Not a JSON object: "oops"]
Either [Value 15 outside of range [0:10]; Not a JSON object: 15]
```

As you can see, the second set of errors both clearly identify that there was an `Either` in play here, and also report how neither of the either were able to decode the input.

Both errors are included in the error message, which gives better feedback to the end consumer of these errors and helps identify what was incorrect about their data.