### PR TITLE
Make map codecs more resistant to erroring entries. Fixes MC-197860

### DIFF
--- a/src/main/java/com/mojang/serialization/codecs/BaseMapCodec.java
+++ b/src/main/java/com/mojang/serialization/codecs/BaseMapCodec.java
@@ -32,11 +32,8 @@ public interface BaseMapCodec<K, V> {
 
                 final DataResult<Pair<K, V>> entry = k.apply2stable(Pair::of, v);
                 entry.error().ifPresent(e -> failed.add(pair));
-
-                return r.apply2stable((u, p) -> {
-                    read.put(p.getFirst(), p.getSecond());
-                    return u;
-                }, entry);
+                entry.result().ifPresent(e -> read.put(e.getFirst(), e.getSecond()));
+                return r.apply2stable((u, p) -> u, entry);
             },
             (r1, r2) -> r1.apply2stable((u1, u2) -> u1, r2)
         );


### PR DESCRIPTION
This is a really simple change that I believe fixes MC-197860. More details are in the issue there, but the root of the problem is the `UnboundedMapCodec`'s behavior in the case of erroring entries. Previously, this (along with any other `BaseMapCodec` implementor) would discard all valid entries after an error, while only actually reporting actual erroring entries.

This PR moves the collection of read results outside the check for the data result in the accumulator, such that all valid entries will get added to the immutable map builder, while keeping intact the behavior of the `apply2stable` on the actual success or failure of the result in question.