### PR TITLE
[CVE-2021-44228]: Update Log4J to resolve security issues

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -35,7 +35,9 @@ repositories {
 dependencies {
     compile 'com.google.code.findbugs:jsr305:2.0.1'
     compile 'com.google.code.gson:gson:2.8.0'
-    compile 'org.apache.logging.log4j:log4j-api:2.8.1'
+    compile 'org.apache.logging.log4j:log4j-api:2.15.0'
+    compile 'org.apache.logging.log4j:log4j-core:2.15.0'
+    compile 'org.apache.logging.log4j:log4j-slf4j18-impl:2.15.0'
     compile 'com.google.guava:guava:21.0'
     compile 'org.apache.commons:commons-lang3:3.5'
     compile 'it.unimi.dsi:fastutil:7.1.0'

--- a/build.gradle
+++ b/build.gradle
@@ -35,9 +35,9 @@ repositories {
 dependencies {
     compile 'com.google.code.findbugs:jsr305:2.0.1'
     compile 'com.google.code.gson:gson:2.8.0'
-    compile 'org.apache.logging.log4j:log4j-api:2.16.0'
-    compile 'org.apache.logging.log4j:log4j-core:2.16.0'
-    compile 'org.apache.logging.log4j:log4j-slf4j18-impl:2.16.0'
+    compile 'org.apache.logging.log4j:log4j-api:2.17.0'
+    compile 'org.apache.logging.log4j:log4j-core:2.17.0'
+    compile 'org.apache.logging.log4j:log4j-slf4j18-impl:2.17.0'
     compile 'com.google.guava:guava:21.0'
     compile 'org.apache.commons:commons-lang3:3.5'
     compile 'it.unimi.dsi:fastutil:7.1.0'

--- a/build.gradle
+++ b/build.gradle
@@ -35,9 +35,9 @@ repositories {
 dependencies {
     compile 'com.google.code.findbugs:jsr305:2.0.1'
     compile 'com.google.code.gson:gson:2.8.0'
-    compile 'org.apache.logging.log4j:log4j-api:2.15.0'
-    compile 'org.apache.logging.log4j:log4j-core:2.15.0'
-    compile 'org.apache.logging.log4j:log4j-slf4j18-impl:2.15.0'
+    compile 'org.apache.logging.log4j:log4j-api:2.16.0'
+    compile 'org.apache.logging.log4j:log4j-core:2.16.0'
+    compile 'org.apache.logging.log4j:log4j-slf4j18-impl:2.16.0'
     compile 'com.google.guava:guava:21.0'
     compile 'org.apache.commons:commons-lang3:3.5'
     compile 'it.unimi.dsi:fastutil:7.1.0'

--- a/build.gradle
+++ b/build.gradle
@@ -35,9 +35,9 @@ repositories {
 dependencies {
     compile 'com.google.code.findbugs:jsr305:2.0.1'
     compile 'com.google.code.gson:gson:2.8.0'
-    compile 'org.apache.logging.log4j:log4j-api:2.17.0'
-    compile 'org.apache.logging.log4j:log4j-core:2.17.0'
-    compile 'org.apache.logging.log4j:log4j-slf4j18-impl:2.17.0'
+    compile 'org.apache.logging.log4j:log4j-api:2.17.1'
+    compile 'org.apache.logging.log4j:log4j-core:2.17.1'
+    compile 'org.apache.logging.log4j:log4j-slf4j18-impl:2.17.1'
     compile 'com.google.guava:guava:21.0'
     compile 'org.apache.commons:commons-lang3:3.5'
     compile 'it.unimi.dsi:fastutil:7.1.0'


### PR DESCRIPTION
Without this, downstream projects that depend on DataFixerUpper may become vulnerable if they don't explicitly specify which log4j version to use.