### PR TITLE
Data fixer performance - easy bits

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,1 @@
-majorMinor: 5.1
+majorMinor: 6.0

--- a/src/main/java/com/mojang/datafixers/DSL.java
+++ b/src/main/java/com/mojang/datafixers/DSL.java
@@ -25,6 +25,7 @@ import com.mojang.datafixers.util.Pair;
 import com.mojang.datafixers.util.Unit;
 import com.mojang.serialization.Codec;
 import com.mojang.serialization.Dynamic;
+import it.unimi.dsi.fastutil.objects.Object2ObjectOpenHashMap;
 import org.apache.commons.lang3.ArrayUtils;
 import org.apache.commons.lang3.tuple.Triple;
 
@@ -191,7 +192,7 @@ public interface DSL {
     }
 
     static <K> TaggedChoice<K> taggedChoice(final String name, final Type<K> keyType, final Map<K, TypeTemplate> templates) {
-        return new TaggedChoice<>(name, keyType, templates);
+        return new TaggedChoice<>(name, keyType, new Object2ObjectOpenHashMap<>(templates));
     }
 
     static <K> TaggedChoice<K> taggedChoiceLazy(final String name, final Type<K> keyType, final Map<K, Supplier<TypeTemplate>> templates) {
@@ -200,7 +201,7 @@ public interface DSL {
 
     @SuppressWarnings("unchecked")
     static <K> Type<Pair<K, ?>> taggedChoiceType(final String name, final Type<K> keyType, final Map<K, ? extends Type<?>> types) {
-        return (Type<Pair<K, ?>>) Instances.TAGGED_CHOICE_TYPE_CACHE.computeIfAbsent(Triple.of(name, keyType, types), k -> new TaggedChoice.TaggedChoiceType<>(k.getLeft(), (Type<K>) k.getMiddle(), (Map<K, Type<?>>) k.getRight()));
+        return (Type<Pair<K, ?>>) Instances.TAGGED_CHOICE_TYPE_CACHE.computeIfAbsent(Triple.of(name, keyType, types), k -> new TaggedChoice.TaggedChoiceType<>(k.getLeft(), (Type<K>) k.getMiddle(), new Object2ObjectOpenHashMap<>((Map<K, Type<?>>) k.getRight())));
     }
 
     static <A, B> Type<Function<A, B>> func(final Type<A> input, final Type<B> output) {

--- a/src/main/java/com/mojang/datafixers/DataFix.java
+++ b/src/main/java/com/mojang/datafixers/DataFix.java
@@ -151,7 +151,7 @@ public abstract class DataFix {
 
         @Override
         public int hashCode() {
-            return Objects.hash(name);
+            return name.hashCode();
         }
     }
 }

--- a/src/main/java/com/mojang/datafixers/DataFixerUpper.java
+++ b/src/main/java/com/mojang/datafixers/DataFixerUpper.java
@@ -2,7 +2,6 @@
 // Licensed under the MIT license.
 package com.mojang.datafixers;
 
-import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
 import com.mojang.datafixers.functions.PointFreeRule;
 import com.mojang.datafixers.schemas.Schema;
@@ -44,25 +43,25 @@ public class DataFixerUpper implements DataFixer {
     private static final Logger LOGGER = LoggerFactory.getLogger(DataFixerUpper.class);
 
     protected static final PointFreeRule OPTIMIZATION_RULE = DataFixUtils.make(() -> {
-        final PointFreeRule opSimple = PointFreeRule.orElse(
-            PointFreeRule.orElse(
+        final PointFreeRule opSimple = PointFreeRule.choice(
+            PointFreeRule.choice(
                 PointFreeRule.CataFuseSame.INSTANCE,
-                PointFreeRule.orElse(
+                PointFreeRule.choice(
                     PointFreeRule.CataFuseDifferent.INSTANCE,
                     PointFreeRule.LensAppId.INSTANCE
                 )
             ),
-            PointFreeRule.orElse(
+            PointFreeRule.choice(
                 PointFreeRule.LensComp.INSTANCE,
-                PointFreeRule.orElse(
+                PointFreeRule.choice(
                     PointFreeRule.AppNest.INSTANCE,
                     PointFreeRule.LensCompFunc.INSTANCE
                 )
             )
         );
-        final PointFreeRule opLeft = PointFreeRule.many(PointFreeRule.once(PointFreeRule.orElse(opSimple, PointFreeRule.CompAssocLeft.INSTANCE)));
-        final PointFreeRule opComp = PointFreeRule.many(PointFreeRule.once(PointFreeRule.orElse(PointFreeRule.SortInj.INSTANCE, PointFreeRule.SortProj.INSTANCE)));
-        final PointFreeRule opRight = PointFreeRule.many(PointFreeRule.once(PointFreeRule.orElse(opSimple, PointFreeRule.CompAssocRight.INSTANCE)));
+        final PointFreeRule opLeft = PointFreeRule.many(PointFreeRule.once(PointFreeRule.choice(opSimple, PointFreeRule.CompAssocLeft.INSTANCE)));
+        final PointFreeRule opComp = PointFreeRule.many(PointFreeRule.once(PointFreeRule.choice(PointFreeRule.SortInj.INSTANCE, PointFreeRule.SortProj.INSTANCE)));
+        final PointFreeRule opRight = PointFreeRule.many(PointFreeRule.once(PointFreeRule.choice(opSimple, PointFreeRule.CompAssocRight.INSTANCE)));
         return PointFreeRule.seq(opLeft, opComp, opRight, opLeft, opRight);
     });
 

--- a/src/main/java/com/mojang/datafixers/DataFixerUpper.java
+++ b/src/main/java/com/mojang/datafixers/DataFixerUpper.java
@@ -44,20 +44,12 @@ public class DataFixerUpper implements DataFixer {
 
     protected static final PointFreeRule OPTIMIZATION_RULE = DataFixUtils.make(() -> {
         final PointFreeRule opSimple = PointFreeRule.choice(
-            PointFreeRule.choice(
-                PointFreeRule.CataFuseSame.INSTANCE,
-                PointFreeRule.choice(
-                    PointFreeRule.CataFuseDifferent.INSTANCE,
-                    PointFreeRule.LensAppId.INSTANCE
-                )
-            ),
-            PointFreeRule.choice(
-                PointFreeRule.LensComp.INSTANCE,
-                PointFreeRule.choice(
-                    PointFreeRule.AppNest.INSTANCE,
-                    PointFreeRule.LensCompFunc.INSTANCE
-                )
-            )
+            PointFreeRule.CataFuseSame.INSTANCE,
+            PointFreeRule.CataFuseDifferent.INSTANCE,
+            PointFreeRule.LensAppId.INSTANCE,
+            PointFreeRule.LensComp.INSTANCE,
+            PointFreeRule.AppNest.INSTANCE,
+            PointFreeRule.LensCompFunc.INSTANCE
         );
         final PointFreeRule opLeft = PointFreeRule.many(PointFreeRule.once(PointFreeRule.choice(opSimple, PointFreeRule.CompAssocLeft.INSTANCE)));
         final PointFreeRule opComp = PointFreeRule.many(PointFreeRule.once(PointFreeRule.choice(PointFreeRule.SortInj.INSTANCE, PointFreeRule.SortProj.INSTANCE)));

--- a/src/main/java/com/mojang/datafixers/DataFixerUpper.java
+++ b/src/main/java/com/mojang/datafixers/DataFixerUpper.java
@@ -63,7 +63,7 @@ public class DataFixerUpper implements DataFixer {
         final PointFreeRule opLeft = PointFreeRule.many(PointFreeRule.once(PointFreeRule.orElse(opSimple, PointFreeRule.CompAssocLeft.INSTANCE)));
         final PointFreeRule opComp = PointFreeRule.many(PointFreeRule.once(PointFreeRule.orElse(PointFreeRule.SortInj.INSTANCE, PointFreeRule.SortProj.INSTANCE)));
         final PointFreeRule opRight = PointFreeRule.many(PointFreeRule.once(PointFreeRule.orElse(opSimple, PointFreeRule.CompAssocRight.INSTANCE)));
-        return PointFreeRule.seq(ImmutableList.of(() -> opLeft, () -> opComp, () -> opRight, () -> opLeft, () -> opRight));
+        return PointFreeRule.seq(opLeft, opComp, opRight, opLeft, opRight);
     });
 
     private final Int2ObjectSortedMap<Schema> schemas;

--- a/src/main/java/com/mojang/datafixers/FieldFinder.java
+++ b/src/main/java/com/mojang/datafixers/FieldFinder.java
@@ -50,7 +50,9 @@ public final class FieldFinder<FT> implements OpticFinder<FT> {
 
     @Override
     public int hashCode() {
-        return Objects.hash(name, type);
+        int result = name != null ? name.hashCode() : 0;
+        result = 31 * result + type.hashCode();
+        return result;
     }
 
     private static final class Matcher<FT, FR> implements Type.TypeMatcher<FT, FR> {
@@ -136,7 +138,10 @@ public final class FieldFinder<FT> implements OpticFinder<FT> {
 
         @Override
         public int hashCode() {
-            return Objects.hash(resultType, name, type);
+            int result = resultType.hashCode();
+            result = 31 * result + (name != null ? name.hashCode() : 0);
+            result = 31 * result + type.hashCode();
+            return result;
         }
     }
 }

--- a/src/main/java/com/mojang/datafixers/FieldFinder.java
+++ b/src/main/java/com/mojang/datafixers/FieldFinder.java
@@ -118,7 +118,7 @@ public final class FieldFinder<FT> implements OpticFinder<FT> {
                 (Type<Pair<FT, V>>) choiceType,
                 type,
                 type,
-                new Proj1<>()
+                Optics.proj1()
             );
         }
 

--- a/src/main/java/com/mojang/datafixers/NamedChoiceFinder.java
+++ b/src/main/java/com/mojang/datafixers/NamedChoiceFinder.java
@@ -44,7 +44,9 @@ final class NamedChoiceFinder<FT> implements OpticFinder<FT> {
 
     @Override
     public int hashCode() {
-        return Objects.hash(name, type);
+        int result = name.hashCode();
+        result = 31 * result + type.hashCode();
+        return result;
     }
 
     private static class Matcher<FT, FR> implements Type.TypeMatcher<FT, FR> {
@@ -102,7 +104,10 @@ final class NamedChoiceFinder<FT> implements OpticFinder<FT> {
 
         @Override
         public int hashCode() {
-            return Objects.hash(resultType, name, type);
+            int result = resultType.hashCode();
+            result = 31 * result + name.hashCode();
+            result = 31 * result + type.hashCode();
+            return result;
         }
     }
 }

--- a/src/main/java/com/mojang/datafixers/OpticParts.java
+++ b/src/main/java/com/mojang/datafixers/OpticParts.java
@@ -11,20 +11,5 @@ import java.util.Set;
 /**
  * apply(i).sType == family.apply(i)
  */
-public final class OpticParts<A, B> {
-    private final Set<TypeToken<? extends K1>> bounds;
-    private final Optic<?, ?, ?, A, B> optic;
-
-    public OpticParts(final Set<TypeToken<? extends K1>> bounds, final Optic<?, ?, ?, A, B> optic) {
-        this.bounds = bounds;
-        this.optic = optic;
-    }
-
-    public Set<TypeToken<? extends K1>> bounds() {
-        return bounds;
-    }
-
-    public Optic<?, ?, ?, A, B> optic() {
-        return optic;
-    }
+public record OpticParts<A, B>(Set<TypeToken<? extends K1>> bounds, Optic<?, ?, ?, A, B> optic) {
 }

--- a/src/main/java/com/mojang/datafixers/RewriteResult.java
+++ b/src/main/java/com/mojang/datafixers/RewriteResult.java
@@ -49,6 +49,6 @@ public record RewriteResult<A, B>(View<A, B> view, BitSet recData) {
 
     @Override
     public int hashCode() {
-        return Objects.hash(view);
+        return view.hashCode();
     }
 }

--- a/src/main/java/com/mojang/datafixers/RewriteResult.java
+++ b/src/main/java/com/mojang/datafixers/RewriteResult.java
@@ -9,15 +9,7 @@ import org.apache.commons.lang3.ObjectUtils;
 import java.util.BitSet;
 import java.util.Objects;
 
-public final class RewriteResult<A, B> {
-    protected final View<A, B> view;
-    protected final BitSet recData;
-
-    public RewriteResult(final View<A, B> view, final BitSet recData) {
-        this.view = view;
-        this.recData = recData;
-    }
-
+public record RewriteResult<A, B>(View<A, B> view, BitSet recData) {
     public static <A, B> RewriteResult<A, B> create(final View<A, B> view, final BitSet recData) {
         return new RewriteResult<>(view, recData);
     }
@@ -36,14 +28,6 @@ public final class RewriteResult<A, B> {
             newData = recData;
         }
         return create(view.compose(that.view), newData);
-    }
-
-    public BitSet recData() {
-        return recData;
-    }
-
-    public View<A, B> view() {
-        return view;
     }
 
     @Override

--- a/src/main/java/com/mojang/datafixers/TypeRewriteRule.java
+++ b/src/main/java/com/mojang/datafixers/TypeRewriteRule.java
@@ -3,7 +3,6 @@
 package com.mojang.datafixers;
 
 import com.google.common.collect.ImmutableList;
-import com.mojang.datafixers.functions.Functions;
 import com.mojang.datafixers.functions.PointFreeRule;
 import com.mojang.datafixers.types.Type;
 
@@ -224,7 +223,7 @@ public interface TypeRewriteRule {
         @Override
         public <A> Optional<RewriteResult<A, ?>> rewrite(final Type<A> type) {
             final Optional<RewriteResult<A, ?>> result = rule.rewrite(type);
-            if (!result.isPresent() || Functions.isId(result.get().view().function())) {
+            if (!result.isPresent() || result.get().view().isNop()) {
                 onFail.accept(type);
             }
             return result;

--- a/src/main/java/com/mojang/datafixers/TypeRewriteRule.java
+++ b/src/main/java/com/mojang/datafixers/TypeRewriteRule.java
@@ -84,7 +84,7 @@ public interface TypeRewriteRule {
         }
 
         protected <A, B> Optional<RewriteResult<A, ?>> cap1(final TypeRewriteRule rule, final RewriteResult<A, B> f) {
-            return rule.rewrite(f.view.newType).map(s -> s.compose(f));
+            return rule.rewrite(f.view().newType()).map(s -> s.compose(f));
         }
 
         @Override
@@ -213,65 +213,21 @@ public interface TypeRewriteRule {
         }
     }
 
-    class One implements TypeRewriteRule {
-        private final TypeRewriteRule rule;
-
-        public One(final TypeRewriteRule rule) {
-            this.rule = rule;
-        }
-
+    record One(TypeRewriteRule rule) implements TypeRewriteRule {
         @Override
         public <A> Optional<RewriteResult<A, ?>> rewrite(final Type<A> type) {
             return type.one(rule);
         }
-
-        @Override
-        public boolean equals(final Object obj) {
-            if (obj == this) {
-                return true;
-            }
-            if (!(obj instanceof One)) {
-                return false;
-            }
-            final One that = (One) obj;
-            return Objects.equals(rule, that.rule);
-        }
-
-        @Override
-        public int hashCode() {
-            return rule.hashCode();
-        }
     }
 
-    class CheckOnce implements TypeRewriteRule {
-        private final TypeRewriteRule rule;
-        private final Consumer<Type<?>> onFail;
-
-        public CheckOnce(final TypeRewriteRule rule, final Consumer<Type<?>> onFail) {
-            this.rule = rule;
-            this.onFail = onFail;
-        }
-
+    record CheckOnce(TypeRewriteRule rule, Consumer<Type<?>> onFail) implements TypeRewriteRule {
         @Override
         public <A> Optional<RewriteResult<A, ?>> rewrite(final Type<A> type) {
             final Optional<RewriteResult<A, ?>> result = rule.rewrite(type);
-            if (!result.isPresent() || Functions.isId(result.get().view.function())) {
+            if (!result.isPresent() || Functions.isId(result.get().view().function())) {
                 onFail.accept(type);
             }
             return result;
-        }
-
-        @Override
-        public boolean equals(final Object o) {
-            if (this == o) {
-                return true;
-            }
-            return o instanceof CheckOnce && Objects.equals(rule, ((CheckOnce) o).rule);
-        }
-
-        @Override
-        public int hashCode() {
-            return Objects.hash(rule);
         }
     }
 

--- a/src/main/java/com/mojang/datafixers/TypeRewriteRule.java
+++ b/src/main/java/com/mojang/datafixers/TypeRewriteRule.java
@@ -255,7 +255,7 @@ public interface TypeRewriteRule {
         @Override
         public <A> Optional<RewriteResult<A, ?>> rewrite(final Type<A> type) {
             final Optional<RewriteResult<A, ?>> result = rule.rewrite(type);
-            if (!result.isPresent() || Objects.equals(result.get().view.function(), Functions.id())) {
+            if (!result.isPresent() || Functions.isId(result.get().view.function())) {
                 onFail.accept(type);
             }
             return result;

--- a/src/main/java/com/mojang/datafixers/Typed.java
+++ b/src/main/java/com/mojang/datafixers/Typed.java
@@ -184,11 +184,11 @@ public final class Typed<A> {
     }
 
     public <B> Typed<Either<A, B>> inj1(final Type<B> type) {
-        return new Typed<>(DSL.or(this.type, type), ops, new Inj1<A, B, A>().build(value));
+        return new Typed<>(DSL.or(this.type, type), ops, Optics.<A, B, A>inj1().build(value));
     }
 
     public <B> Typed<Either<B, A>> inj2(final Type<B> type) {
-        return new Typed<>(DSL.or(type, this.type), ops, new Inj2<B, A, A>().build(value));
+        return new Typed<>(DSL.or(type, this.type), ops, Optics.<B, A, A>inj2().build(value));
     }
 
     public static <A, B> Typed<Pair<A, B>> pair(final Typed<A> first, final Typed<B> second) {

--- a/src/main/java/com/mojang/datafixers/TypedOptic.java
+++ b/src/main/java/com/mojang/datafixers/TypedOptic.java
@@ -208,6 +208,9 @@ public final class TypedOptic<S, T, A, B> {
     }
 
     private static <K, A, B> Type<Pair<K, ?>> replaceTagged(final TaggedChoice.TaggedChoiceType<K> sType, final K key, final Type<A> aType, final Type<B> bType) {
+        if (Objects.equals(aType, bType)) {
+            return sType;
+        }
         if (!Objects.equals(sType.types().get(key), aType)) {
             throw new IllegalArgumentException("Focused type doesn't match.");
         }

--- a/src/main/java/com/mojang/datafixers/TypedOptic.java
+++ b/src/main/java/com/mojang/datafixers/TypedOptic.java
@@ -131,7 +131,7 @@ public final class TypedOptic<S, T, A, B> {
             DSL.and(newType, gType),
             fType,
             newType,
-            new Proj1<>()
+            Optics.proj1()
         );
     }
 
@@ -142,7 +142,7 @@ public final class TypedOptic<S, T, A, B> {
             DSL.and(fType, newType),
             gType,
             newType,
-            new Proj2<>()
+            Optics.proj2()
         );
     }
 
@@ -153,7 +153,7 @@ public final class TypedOptic<S, T, A, B> {
             DSL.or(newType, gType),
             fType,
             newType,
-            new Inj1<>()
+            Optics.inj1()
         );
     }
 
@@ -164,7 +164,7 @@ public final class TypedOptic<S, T, A, B> {
             DSL.or(fType, newType),
             gType,
             newType,
-            new Inj2<>()
+            Optics.inj2()
         );
     }
 
@@ -175,7 +175,7 @@ public final class TypedOptic<S, T, A, B> {
             DSL.compoundList(bType, valueType),
             aType,
             bType,
-            new ListTraversal<Pair<K, V>, Pair<K2, V>>().compose(Optics.proj1())
+            Optics.<Pair<K, V>, Pair<K2, V>>listTraversal().compose(Optics.proj1())
         );
     }
 
@@ -186,7 +186,7 @@ public final class TypedOptic<S, T, A, B> {
             DSL.compoundList(keyType, bType),
             aType,
             bType,
-            new ListTraversal<Pair<K, V>, Pair<K, V2>>().compose(Optics.proj2())
+            Optics.<Pair<K, V>, Pair<K, V2>>listTraversal().compose(Optics.proj2())
         );
     }
 
@@ -197,7 +197,7 @@ public final class TypedOptic<S, T, A, B> {
             DSL.list(bType),
             aType,
             bType,
-            new ListTraversal<>()
+            Optics.listTraversal()
         );
     }
 

--- a/src/main/java/com/mojang/datafixers/TypedOptic.java
+++ b/src/main/java/com/mojang/datafixers/TypedOptic.java
@@ -9,14 +9,9 @@ import com.mojang.datafixers.kinds.App;
 import com.mojang.datafixers.kinds.App2;
 import com.mojang.datafixers.kinds.K1;
 import com.mojang.datafixers.kinds.K2;
-import com.mojang.datafixers.optics.Inj1;
-import com.mojang.datafixers.optics.Inj2;
 import com.mojang.datafixers.optics.InjTagged;
-import com.mojang.datafixers.optics.ListTraversal;
 import com.mojang.datafixers.optics.Optic;
 import com.mojang.datafixers.optics.Optics;
-import com.mojang.datafixers.optics.Proj1;
-import com.mojang.datafixers.optics.Proj2;
 import com.mojang.datafixers.optics.profunctors.Cartesian;
 import com.mojang.datafixers.optics.profunctors.Cocartesian;
 import com.mojang.datafixers.optics.profunctors.Profunctor;
@@ -202,19 +197,22 @@ public final class TypedOptic<S, T, A, B> {
     }
 
     public static <K, A, B> TypedOptic<Pair<K, ?>, Pair<K, ?>, A, B> tagged(final TaggedChoice.TaggedChoiceType<K> sType, final K key, final Type<A> aType, final Type<B> bType) {
+        return new TypedOptic<>(
+            Cocartesian.Mu.TYPE_TOKEN,
+            sType,
+            replaceTagged(sType, key, aType, bType),
+            aType,
+            bType,
+            new InjTagged<>(key)
+        );
+    }
+
+    private static <K, A, B> Type<Pair<K, ?>> replaceTagged(final TaggedChoice.TaggedChoiceType<K> sType, final K key, final Type<A> aType, final Type<B> bType) {
         if (!Objects.equals(sType.types().get(key), aType)) {
             throw new IllegalArgumentException("Focused type doesn't match.");
         }
         final Map<K, Type<?>> newTypes = Maps.newHashMap(sType.types());
         newTypes.put(key, bType);
-        final Type<Pair<K, ?>> pairType = DSL.taggedChoiceType(sType.getName(), sType.getKeyType(), newTypes);
-        return new TypedOptic<>(
-            Cocartesian.Mu.TYPE_TOKEN,
-            sType,
-            pairType,
-            aType,
-            bType,
-            new InjTagged<>(key)
-        );
+        return DSL.taggedChoiceType(sType.getName(), sType.getKeyType(), newTypes);
     }
 }

--- a/src/main/java/com/mojang/datafixers/View.java
+++ b/src/main/java/com/mojang/datafixers/View.java
@@ -57,12 +57,16 @@ public record View<A, B>(Type<A> type, Type<B> newType, PointFree<Function<A, B>
 
     @SuppressWarnings("unchecked")
     public <C> View<C, B> compose(final View<C, A> that) {
-        if (Functions.isId(function())) {
+        if (isNop()) {
             return new View<>(that.type(), newType(), ((View<C, B>) that).function());
         }
-        if (Functions.isId(that.function())) {
+        if (that.isNop()) {
             return new View<>(that.type(), newType(), ((View<C, B>) this).function());
         }
         return create(that.type, newType, Functions.comp(that.newType, function(), that.function()));
+    }
+
+    public boolean isNop() {
+        return Functions.isId(function());
     }
 }

--- a/src/main/java/com/mojang/datafixers/View.java
+++ b/src/main/java/com/mojang/datafixers/View.java
@@ -96,10 +96,10 @@ public final class View<A, B> implements App2<View.Mu, A, B> {
 
     @SuppressWarnings("unchecked")
     public <C> View<C, B> compose(final View<C, A> that) {
-        if (Objects.equals(function(), Functions.id())) {
+        if (Functions.isId(function())) {
             return new View<>(that.type(), newType(), ((View<C, B>) that).function());
         }
-        if (Objects.equals(that.function(), Functions.id())) {
+        if (Functions.isId(that.function())) {
             return new View<>(that.type(), newType(), ((View<C, B>) this).function());
         }
         return create(that.type, newType, Functions.comp(that.newType, function(), that.function()));

--- a/src/main/java/com/mojang/datafixers/View.java
+++ b/src/main/java/com/mojang/datafixers/View.java
@@ -14,7 +14,7 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.function.Function;
 
-public final class View<A, B> implements App2<View.Mu, A, B> {
+public record View<A, B>(Type<A> type, Type<B> newType, PointFree<Function<A, B>> function) implements App2<View.Mu, A, B> {
     static final class Mu implements K2 {}
 
     static <A, B> View<A, B> unbox(final App2<Mu, A, B> box) {
@@ -25,52 +25,13 @@ public final class View<A, B> implements App2<View.Mu, A, B> {
         return create(type, type, Functions.id());
     }
 
-    private final Type<A> type;
-    protected final Type<B> newType;
-    private final PointFree<Function<A, B>> function;
-
-    public View(final Type<A> type, final Type<B> newType, final PointFree<Function<A, B>> function) {
-        this.type = type;
-        this.newType = newType;
-        this.function = function;
-    }
-
-    public Type<A> type() {
-        return type;
-    }
-
-    public Type<B> newType() {
-        return newType;
-    }
-
-    public PointFree<Function<A, B>> function() {
-        return function;
-    }
-
-    public Type<Function<A, B>> getFuncType() {
+    public Type<Function<A, B>> funcType() {
         return DSL.func(type, newType);
     }
 
     @Override
     public String toString() {
         return "View[" + function + "," + newType + "]";
-    }
-
-    @Override
-    public boolean equals(final Object o) {
-        if (this == o) {
-            return true;
-        }
-        if (o == null || getClass() != o.getClass()) {
-            return false;
-        }
-        final View<?, ?> view = (View<?, ?>) o;
-        return Objects.equals(type, view.type) && Objects.equals(newType, view.newType) && Objects.equals(function, view.function);
-    }
-
-    @Override
-    public int hashCode() {
-        return Objects.hash(type, newType, function);
     }
 
     public Optional<? extends View<A, B>> rewrite(final PointFreeRule rule) {

--- a/src/main/java/com/mojang/datafixers/functions/Apply.java
+++ b/src/main/java/com/mojang/datafixers/functions/Apply.java
@@ -60,6 +60,8 @@ final class Apply<A, B> extends PointFree<B> {
 
     @Override
     public int hashCode() {
-        return Objects.hash(func, arg);
+        int result = func.hashCode();
+        result = 31 * result + arg.hashCode();
+        return result;
     }
 }

--- a/src/main/java/com/mojang/datafixers/functions/Comp.java
+++ b/src/main/java/com/mojang/datafixers/functions/Comp.java
@@ -24,7 +24,7 @@ final class Comp<A, B, C> extends PointFree<Function<A, C>> {
 
     @Override
     public String toString(final int level) {
-        return "(\n" + indent(level + 1) + first.toString(level + 1) + "\n" + indent(level + 1) + "◦\n" + indent(level + 1) + second.toString(level + 1) + "\n" + indent(level) + ")";
+        return "(\n" + indent(level + 1) + first.toString(level + 1) + "\n" + indent(level + 1) + "\u25E6\n" + indent(level + 1) + second.toString(level + 1) + "\n" + indent(level) + ")";
     }
 
     @Override

--- a/src/main/java/com/mojang/datafixers/functions/Comp.java
+++ b/src/main/java/com/mojang/datafixers/functions/Comp.java
@@ -58,7 +58,9 @@ final class Comp<A, B, C> extends PointFree<Function<A, C>> {
 
     @Override
     public int hashCode() {
-        return Objects.hash(first, second);
+        int result = first.hashCode();
+        result = 31 * result + second.hashCode();
+        return result;
     }
 
     @Override

--- a/src/main/java/com/mojang/datafixers/functions/Fold.java
+++ b/src/main/java/com/mojang/datafixers/functions/Fold.java
@@ -68,6 +68,8 @@ final class Fold<A, B> extends PointFree<Function<A, B>> {
 
     @Override
     public int hashCode() {
-        return Objects.hash(aType, algebra);
+        int result = aType.hashCode();
+        result = 31 * result + algebra.hashCode();
+        return result;
     }
 }

--- a/src/main/java/com/mojang/datafixers/functions/FunctionWrapper.java
+++ b/src/main/java/com/mojang/datafixers/functions/FunctionWrapper.java
@@ -35,7 +35,7 @@ final class FunctionWrapper<A, B> extends PointFree<Function<A, B>> {
 
     @Override
     public int hashCode() {
-        return Objects.hash(fun);
+        return fun.hashCode();
     }
 
     @Override

--- a/src/main/java/com/mojang/datafixers/functions/Functions.java
+++ b/src/main/java/com/mojang/datafixers/functions/Functions.java
@@ -5,6 +5,7 @@ package com.mojang.datafixers.functions;
 import com.mojang.datafixers.FunctionType;
 import com.mojang.datafixers.RewriteResult;
 import com.mojang.datafixers.optics.Optic;
+import com.mojang.datafixers.types.Func;
 import com.mojang.datafixers.types.Type;
 import com.mojang.datafixers.types.families.Algebra;
 import com.mojang.datafixers.types.templates.RecursivePoint;
@@ -14,14 +15,12 @@ import java.util.Objects;
 import java.util.function.Function;
 
 public abstract class Functions {
-    private static final Id<?> ID = new Id<>();
-
     @SuppressWarnings("unchecked")
     public static <A, B, C> PointFree<Function<A, C>> comp(final Type<B> middleType, final PointFree<Function<B, C>> f1, final PointFree<Function<A, B>> f2) {
-        if (Objects.equals(f1, id())) {
+        if (Functions.isId(f1)) {
             return (PointFree<Function<A, C>>) (PointFree<?>) f2;
         }
-        if (Objects.equals(f2, id())) {
+        if (Functions.isId(f2)) {
             return (PointFree<Function<A, C>>) (PointFree<?>) f1;
         }
         return new Comp<>(middleType, f1, f2);
@@ -57,6 +56,10 @@ public abstract class Functions {
 
     @SuppressWarnings("unchecked")
     public static <A> PointFree<Function<A, A>> id() {
-        return (Id<A>) ID;
+        return (Id<A>) Id.INSTANCE;
+    }
+
+    public static boolean isId(final PointFree<?> function) {
+        return function == Id.INSTANCE;
     }
 }

--- a/src/main/java/com/mojang/datafixers/functions/Id.java
+++ b/src/main/java/com/mojang/datafixers/functions/Id.java
@@ -7,12 +7,9 @@ import com.mojang.serialization.DynamicOps;
 import java.util.function.Function;
 
 final class Id<A> extends PointFree<Function<A, A>> {
-    public Id() {
-    }
+    public static final Id<?> INSTANCE = new Id<>();
 
-    @Override
-    public boolean equals(final Object obj) {
-        return obj instanceof Id<?>;
+    private Id() {
     }
 
     @Override

--- a/src/main/java/com/mojang/datafixers/functions/In.java
+++ b/src/main/java/com/mojang/datafixers/functions/In.java
@@ -30,7 +30,7 @@ final class In<A> extends PointFree<Function<A, A>> {
 
     @Override
     public int hashCode() {
-        return Objects.hash(type);
+        return type.hashCode();
     }
 
     @Override

--- a/src/main/java/com/mojang/datafixers/functions/Out.java
+++ b/src/main/java/com/mojang/datafixers/functions/Out.java
@@ -30,7 +30,7 @@ final class Out<A> extends PointFree<Function<A, A>> {
 
     @Override
     public int hashCode() {
-        return Objects.hash(type);
+        return type.hashCode();
     }
 
     @Override

--- a/src/main/java/com/mojang/datafixers/functions/PointFreeRule.java
+++ b/src/main/java/com/mojang/datafixers/functions/PointFreeRule.java
@@ -32,7 +32,7 @@ public interface PointFreeRule {
     <A> Optional<? extends PointFree<A>> rewrite(final Type<A> type, final PointFree<A> expr);
 
     default <A, B> Optional<View<A, B>> rewrite(final View<A, B> view) {
-        return rewrite(view.getFuncType(), view.function()).map(pf -> View.create(view.type(), view.newType(), pf));
+        return rewrite(view.funcType(), view.function()).map(pf -> View.create(view.type(), view.newType(), pf));
     }
 
     default <A> PointFree<A> rewriteOrNop(final Type<A> type, final PointFree<A> expr) {
@@ -513,13 +513,7 @@ public interface PointFreeRule {
         return new Seq(rules);
     }
 
-    final class Seq implements PointFreeRule {
-        private final PointFreeRule[] rules;
-
-        public Seq(final PointFreeRule... rules) {
-            this.rules = rules;
-        }
-
+    record Seq(PointFreeRule[] rules) implements PointFreeRule {
         @Override
         public <A> Optional<? extends PointFree<A>> rewrite(final Type<A> type, final PointFree<A> expr) {
             Optional<? extends PointFree<A>> result = Optional.of(expr);
@@ -537,11 +531,7 @@ public interface PointFreeRule {
             if (obj == this) {
                 return true;
             }
-            if (!(obj instanceof Seq)) {
-                return false;
-            }
-            final Seq that = (Seq) obj;
-            return Arrays.equals(rules, that.rules);
+            return obj instanceof final Seq that && Arrays.equals(rules, that.rules);
         }
 
         @Override
@@ -559,15 +549,7 @@ public interface PointFreeRule {
         return new Choice(rules);
     }
 
-    final class Choice2 implements PointFreeRule {
-        protected final PointFreeRule first;
-        protected final PointFreeRule second;
-
-        public Choice2(final PointFreeRule first, final PointFreeRule second) {
-            this.first = first;
-            this.second = second;
-        }
-
+    record Choice2(PointFreeRule first, PointFreeRule second) implements PointFreeRule {
         @Override
         public <A> Optional<? extends PointFree<A>> rewrite(final Type<A> type, final PointFree<A> expr) {
             final Optional<? extends PointFree<A>> view = first.rewrite(type, expr);
@@ -575,23 +557,6 @@ public interface PointFreeRule {
                 return view;
             }
             return second.rewrite(type, expr);
-        }
-
-        @Override
-        public boolean equals(final Object obj) {
-            if (obj == this) {
-                return true;
-            }
-            if (!(obj instanceof Choice2)) {
-                return false;
-            }
-            final Choice2 that = (Choice2) obj;
-            return Objects.equals(first, that.first) && Objects.equals(second, that.second);
-        }
-
-        @Override
-        public int hashCode() {
-            return Objects.hash(first, second);
         }
     }
 
@@ -660,73 +625,21 @@ public interface PointFreeRule {
         }
     }
 
-    final class All implements PointFreeRule {
-        private final PointFreeRule rule;
-
-        public All(final PointFreeRule rule) {
-            this.rule = rule;
-        }
-
+    record All(PointFreeRule rule) implements PointFreeRule {
         @Override
         public <A> Optional<? extends PointFree<A>> rewrite(final Type<A> type, final PointFree<A> expr) {
             return expr.all(rule, type);
         }
-
-        @Override
-        public boolean equals(final Object obj) {
-            if (obj == this) {
-                return true;
-            }
-            if (!(obj instanceof All)) {
-                return false;
-            }
-            final All that = (All) obj;
-            return Objects.equals(rule, that.rule);
-        }
-
-        @Override
-        public int hashCode() {
-            return rule.hashCode();
-        }
     }
 
-    final class One implements PointFreeRule {
-        private final PointFreeRule rule;
-
-        public One(final PointFreeRule rule) {
-            this.rule = rule;
-        }
-
+    record One(PointFreeRule rule) implements PointFreeRule {
         @Override
         public <A> Optional<? extends PointFree<A>> rewrite(final Type<A> type, final PointFree<A> expr) {
             return expr.one(rule, type);
         }
-
-        @Override
-        public boolean equals(final Object obj) {
-            if (obj == this) {
-                return true;
-            }
-            if (!(obj instanceof One)) {
-                return false;
-            }
-            final One that = (One) obj;
-            return Objects.equals(rule, that.rule);
-        }
-
-        @Override
-        public int hashCode() {
-            return rule.hashCode();
-        }
     }
 
-    final class Many implements PointFreeRule {
-        private final PointFreeRule rule;
-
-        public Many(final PointFreeRule rule) {
-            this.rule = rule;
-        }
-
+    record Many(PointFreeRule rule) implements PointFreeRule {
         @Override
         public <A> Optional<? extends PointFree<A>> rewrite(final Type<A> type, final PointFree<A> expr) {
             Optional<? extends PointFree<A>> result = Optional.of(expr);
@@ -737,23 +650,6 @@ public interface PointFreeRule {
                 }
                 result = newResult;
             }
-        }
-
-        @Override
-        public boolean equals(final Object o) {
-            if (this == o) {
-                return true;
-            }
-            if (o == null || getClass() != o.getClass()) {
-                return false;
-            }
-            final Many many = (Many) o;
-            return Objects.equals(rule, many.rule);
-        }
-
-        @Override
-        public int hashCode() {
-            return Objects.hash(rule);
         }
     }
 }

--- a/src/main/java/com/mojang/datafixers/functions/PointFreeRule.java
+++ b/src/main/java/com/mojang/datafixers/functions/PointFreeRule.java
@@ -84,6 +84,7 @@ public interface PointFreeRule {
     enum CompAssocLeft implements PointFreeRule {
         INSTANCE;
 
+        // f ◦ (g ◦ h) -> (f ◦ g) ◦ h
         @Override
         public <A> Optional<? extends PointFree<A>> rewrite(final Type<A> type, final PointFree<A> expr) {
             if (expr instanceof Comp<?, ?, ?>) {
@@ -107,6 +108,7 @@ public interface PointFreeRule {
     enum CompAssocRight implements PointFreeRule {
         INSTANCE;
 
+        // (f ◦ g) ◦ h -> f ◦ (g ◦ h)
         @Override
         public <A> Optional<? extends PointFree<A>> rewrite(final Type<A> type, final PointFree<A> expr) {
             if (expr instanceof Comp<?, ?, ?>) {
@@ -175,6 +177,7 @@ public interface PointFreeRule {
                 final Comp<?, ?, ?> comp = (Comp<?, ?, ?>) expr;
                 final PointFree<? extends Function<?, ?>> first = comp.first;
                 final PointFree<? extends Function<?, ?>> second = comp.second;
+                // Rewrite f ◦ g in (_ ◦ f) ◦ g
                 if (first instanceof Comp<?, ?, ?>) {
                     final Comp<?, ?, ?> firstComp = (Comp<?, ?, ?>) first;
                     return doRewrite(type, comp.middleType, firstComp.second, comp.second).map(result -> {
@@ -185,6 +188,7 @@ public interface PointFreeRule {
                         return buildRight(firstComp, result);
                     });
                 }
+                // Rewrite f ◦ g in f ◦ (g ◦ _)
                 if (second instanceof Comp<?, ?, ?>) {
                     final Comp<?, ?, ?> secondComp = (Comp<?, ?, ?>) second;
                     return doRewrite(type, comp.middleType, comp.first, secondComp.first).map(result -> {
@@ -195,6 +199,7 @@ public interface PointFreeRule {
                         return buildLeft(result, secondComp);
                     });
                 }
+                // Rewrite f ◦ g
                 return (Optional<? extends PointFree<A>>) doRewrite(type, comp.middleType, comp.first, comp.second);
             }
             return Optional.empty();

--- a/src/main/java/com/mojang/datafixers/functions/PointFreeRule.java
+++ b/src/main/java/com/mojang/datafixers/functions/PointFreeRule.java
@@ -458,9 +458,6 @@ public interface PointFreeRule {
                         secondModifies.set(i, !secondId);
                     }
 
-                    final BitSet newSet = ObjectUtils.clone(firstModifies);
-                    newSet.or(secondModifies);
-
                     // if the left function doesn't care about the right modifications, and converse is correct, the merge is valid
                     // TODO: verify that this is enough
                     for (int i = 0; i < family.size(); i++) {

--- a/src/main/java/com/mojang/datafixers/functions/PointFreeRule.java
+++ b/src/main/java/com/mojang/datafixers/functions/PointFreeRule.java
@@ -550,15 +550,15 @@ public interface PointFreeRule {
         }
     }
 
-    static PointFreeRule orElse(final PointFreeRule first, final PointFreeRule second) {
-        return new OrElse(first, second);
+    static PointFreeRule choice(final PointFreeRule first, final PointFreeRule second) {
+        return new Choice2(first, second);
     }
 
-    final class OrElse implements PointFreeRule {
+    final class Choice2 implements PointFreeRule {
         protected final PointFreeRule first;
         protected final PointFreeRule second;
 
-        public OrElse(final PointFreeRule first, final PointFreeRule second) {
+        public Choice2(final PointFreeRule first, final PointFreeRule second) {
             this.first = first;
             this.second = second;
         }
@@ -577,10 +577,10 @@ public interface PointFreeRule {
             if (obj == this) {
                 return true;
             }
-            if (!(obj instanceof OrElse)) {
+            if (!(obj instanceof Choice2)) {
                 return false;
             }
-            final OrElse that = (OrElse) obj;
+            final Choice2 that = (Choice2) obj;
             return Objects.equals(first, that.first) && Objects.equals(second, that.second);
         }
 

--- a/src/main/java/com/mojang/datafixers/functions/PointFreeRule.java
+++ b/src/main/java/com/mojang/datafixers/functions/PointFreeRule.java
@@ -412,8 +412,8 @@ public interface PointFreeRule {
                     for (int i = 0; i < family.size(); i++) {
                         final RewriteResult<?, ?> firstAlgFunc = firstFold.algebra.apply(i);
                         final RewriteResult<?, ?> secondAlgFunc = secondFold.algebra.apply(i);
-                        final boolean firstId = Functions.isId(firstAlgFunc.view().function());
-                        final boolean secondId = Functions.isId(secondAlgFunc.view().function());
+                        final boolean firstId = firstAlgFunc.view().isNop();
+                        final boolean secondId = secondAlgFunc.view().isNop();
 
                         if (firstId && secondId) {
                             newAlgebra.add(firstAlgFunc);
@@ -459,8 +459,8 @@ public interface PointFreeRule {
                     for (int i = 0; i < family.size(); i++) {
                         final RewriteResult<?, ?> firstAlgFunc = firstFold.algebra.apply(i);
                         final RewriteResult<?, ?> secondAlgFunc = secondFold.algebra.apply(i);
-                        final boolean firstId = Functions.isId(firstAlgFunc.view().function());
-                        final boolean secondId = Functions.isId(secondAlgFunc.view().function());
+                        final boolean firstId = firstAlgFunc.view().isNop();
+                        final boolean secondId = secondAlgFunc.view().isNop();
                         if (!firstId && !secondId) {
                             return Optional.empty();
                         }
@@ -477,7 +477,7 @@ public interface PointFreeRule {
                             // outer function depends on the result of the inner one
                             return Optional.empty();
                         }
-                        if (Functions.isId(firstAlgFunc.view().function())) {
+                        if (firstAlgFunc.view().isNop()) {
                             newAlgebra.add(secondAlgFunc);
                         } else {
                             newAlgebra.add(firstAlgFunc);

--- a/src/main/java/com/mojang/datafixers/functions/PointFreeRule.java
+++ b/src/main/java/com/mojang/datafixers/functions/PointFreeRule.java
@@ -405,7 +405,7 @@ public interface PointFreeRule {
                     for (int i = 0; i < family.size(); i++) {
                         final RewriteResult<?, ?> firstAlgFunc = firstFold.algebra.apply(i);
                         final RewriteResult<?, ?> secondAlgFunc = secondFold.algebra.apply(i);
-                        final boolean firstId = Functions.isId(CompAssocRight.INSTANCE.rewriteOrNop(firstAlgFunc.view()).function());
+                        final boolean firstId = Functions.isId(firstAlgFunc.view().function());
                         final boolean secondId = Functions.isId(secondAlgFunc.view().function());
 
                         if (firstId && secondId) {
@@ -452,7 +452,7 @@ public interface PointFreeRule {
                     for (int i = 0; i < family.size(); i++) {
                         final RewriteResult<?, ?> firstAlgFunc = firstFold.algebra.apply(i);
                         final RewriteResult<?, ?> secondAlgFunc = secondFold.algebra.apply(i);
-                        final boolean firstId = Functions.isId(CompAssocRight.INSTANCE.rewriteOrNop(firstAlgFunc.view()).function());
+                        final boolean firstId = Functions.isId(firstAlgFunc.view().function());
                         final boolean secondId = Functions.isId(secondAlgFunc.view().function());
                         firstModifies.set(i, !firstId);
                         secondModifies.set(i, !secondId);
@@ -466,10 +466,8 @@ public interface PointFreeRule {
                     for (int i = 0; i < family.size(); i++) {
                         final RewriteResult<?, ?> firstAlgFunc = firstFold.algebra.apply(i);
                         final RewriteResult<?, ?> secondAlgFunc = secondFold.algebra.apply(i);
-                        final PointFree<?> firstF = CompAssocRight.INSTANCE.rewriteOrNop(firstAlgFunc.view()).function();
-                        final PointFree<?> secondF = CompAssocRight.INSTANCE.rewriteOrNop(secondAlgFunc.view()).function();
-                        final boolean firstId = Functions.isId(firstF);
-                        final boolean secondId = Functions.isId(secondF);
+                        final boolean firstId = Functions.isId(firstAlgFunc.view().function());
+                        final boolean secondId = Functions.isId(secondAlgFunc.view().function());
                         if (firstAlgFunc.recData().intersects(secondModifies) || secondAlgFunc.recData().intersects(firstModifies)) {
                             // outer function depends on the result of the inner one
                             return Optional.empty();

--- a/src/main/java/com/mojang/datafixers/functions/PointFreeRule.java
+++ b/src/main/java/com/mojang/datafixers/functions/PointFreeRule.java
@@ -139,7 +139,7 @@ public interface PointFreeRule {
             if (expr instanceof Apply<?, ?>) {
                 final Apply<?, A> apply = (Apply<?, A>) expr;
                 final PointFree<? extends Function<?, A>> func = apply.func;
-                if (func instanceof ProfunctorTransformer<?, ?, ?, ?> && Objects.equals(apply.arg, Functions.id())) {
+                if (func instanceof ProfunctorTransformer<?, ?, ?, ?> && Functions.isId(apply.arg)) {
                     return Optional.of((PointFree<A>) Functions.id());
                 }
             }
@@ -255,7 +255,7 @@ public interface PointFreeRule {
                         so = ((Optic.CompositionOptic<?, ?, ?, ?, ?, ?, ?>) so).outer();
                     }
 
-                    if (Objects.equals(fo, Optics.proj2()) && Objects.equals(so, Optics.proj1())) {
+                    if (Optics.isProj2(fo) && Optics.isProj1(so)) {
                         final Func<?, ?> firstArg = (Func<?, ?>) applyFirst.argType;
                         final Func<?, ?> secondArg = (Func<?, ?>) applySecond.argType;
                         return Optional.of(cap(firstArg, secondArg, applyFirst, applySecond));
@@ -300,7 +300,7 @@ public interface PointFreeRule {
                         so = ((Optic.CompositionOptic<?, ?, ?, ?, ?, ?, ?>) so).outer();
                     }
 
-                    if (Objects.equals(fo, Optics.inj2()) && Objects.equals(so, Optics.inj1())) {
+                    if (Optics.isInj2(fo) && Optics.isInj1(so)) {
                         final Func<?, ?> firstArg = (Func<?, ?>) applyFirst.argType;
                         final Func<?, ?> secondArg = (Func<?, ?>) applySecond.argType;
                         return Optional.of(cap(firstArg, secondArg, applyFirst, applySecond));
@@ -405,8 +405,8 @@ public interface PointFreeRule {
                     for (int i = 0; i < family.size(); i++) {
                         final RewriteResult<?, ?> firstAlgFunc = firstFold.algebra.apply(i);
                         final RewriteResult<?, ?> secondAlgFunc = secondFold.algebra.apply(i);
-                        final boolean firstId = Objects.equals(CompAssocRight.INSTANCE.rewriteOrNop(firstAlgFunc.view()).function(), Functions.id());
-                        final boolean secondId = Objects.equals(secondAlgFunc.view().function(), Functions.id());
+                        final boolean firstId = Functions.isId(CompAssocRight.INSTANCE.rewriteOrNop(firstAlgFunc.view()).function());
+                        final boolean secondId = Functions.isId(secondAlgFunc.view().function());
 
                         if (firstId && secondId) {
                             newAlgebra.add(firstFold.algebra.apply(i));
@@ -452,8 +452,8 @@ public interface PointFreeRule {
                     for (int i = 0; i < family.size(); i++) {
                         final RewriteResult<?, ?> firstAlgFunc = firstFold.algebra.apply(i);
                         final RewriteResult<?, ?> secondAlgFunc = secondFold.algebra.apply(i);
-                        final boolean firstId = Objects.equals(CompAssocRight.INSTANCE.rewriteOrNop(firstAlgFunc.view()).function(), Functions.id());
-                        final boolean secondId = Objects.equals(secondAlgFunc.view().function(), Functions.id());
+                        final boolean firstId = Functions.isId(CompAssocRight.INSTANCE.rewriteOrNop(firstAlgFunc.view()).function());
+                        final boolean secondId = Functions.isId(secondAlgFunc.view().function());
                         firstModifies.set(i, !firstId);
                         secondModifies.set(i, !secondId);
                     }
@@ -468,8 +468,8 @@ public interface PointFreeRule {
                         final RewriteResult<?, ?> secondAlgFunc = secondFold.algebra.apply(i);
                         final PointFree<?> firstF = CompAssocRight.INSTANCE.rewriteOrNop(firstAlgFunc.view()).function();
                         final PointFree<?> secondF = CompAssocRight.INSTANCE.rewriteOrNop(secondAlgFunc.view()).function();
-                        final boolean firstId = Objects.equals(firstF, Functions.id());
-                        final boolean secondId = Objects.equals(secondF, Functions.id());
+                        final boolean firstId = Functions.isId(firstF);
+                        final boolean secondId = Functions.isId(secondF);
                         if (firstAlgFunc.recData().intersects(secondModifies) || secondAlgFunc.recData().intersects(firstModifies)) {
                             // outer function depends on the result of the inner one
                             return Optional.empty();

--- a/src/main/java/com/mojang/datafixers/functions/ProfunctorTransformer.java
+++ b/src/main/java/com/mojang/datafixers/functions/ProfunctorTransformer.java
@@ -45,6 +45,6 @@ final class ProfunctorTransformer<S, T, A, B> extends PointFree<Function<Functio
 
     @Override
     public int hashCode() {
-        return Objects.hash(optic);
+        return optic.hashCode();
     }
 }

--- a/src/main/java/com/mojang/datafixers/optics/IdAdapter.java
+++ b/src/main/java/com/mojang/datafixers/optics/IdAdapter.java
@@ -3,6 +3,11 @@
 package com.mojang.datafixers.optics;
 
 class IdAdapter<S, T> implements Adapter<S, T, S, T> {
+    static final IdAdapter<?, ?> INSTANCE = new IdAdapter<>();
+
+    private IdAdapter() {
+    }
+
     @Override
     public S from(final S s) {
         return s;
@@ -11,11 +16,6 @@ class IdAdapter<S, T> implements Adapter<S, T, S, T> {
     @Override
     public T to(final T b) {
         return b;
-    }
-
-    @Override
-    public boolean equals(final Object obj) {
-        return obj instanceof IdAdapter<?, ?>;
     }
 
     @Override

--- a/src/main/java/com/mojang/datafixers/optics/Inj1.java
+++ b/src/main/java/com/mojang/datafixers/optics/Inj1.java
@@ -5,6 +5,11 @@ package com.mojang.datafixers.optics;
 import com.mojang.datafixers.util.Either;
 
 public final class Inj1<F, G, F2> implements Prism<Either<F, G>, Either<F2, G>, F, F2> {
+    public static final Inj1<?, ?, ?> INSTANCE = new Inj1<>();
+
+    private Inj1() {
+    }
+
     @Override
     public Either<Either<F2, G>, F> match(final Either<F, G> either) {
         return either.map(Either::right, g -> Either.left(Either.right(g)));
@@ -18,10 +23,5 @@ public final class Inj1<F, G, F2> implements Prism<Either<F, G>, Either<F2, G>, 
     @Override
     public String toString() {
         return "inj1";
-    }
-
-    @Override
-    public boolean equals(final Object obj) {
-        return obj instanceof Inj1<?, ?, ?>;
     }
 }

--- a/src/main/java/com/mojang/datafixers/optics/Inj2.java
+++ b/src/main/java/com/mojang/datafixers/optics/Inj2.java
@@ -5,6 +5,11 @@ package com.mojang.datafixers.optics;
 import com.mojang.datafixers.util.Either;
 
 public final class Inj2<F, G, G2> implements Prism<Either<F, G>, Either<F, G2>, G, G2> {
+    public static final Inj2<?, ?, ?> INSTANCE = new Inj2<>();
+
+    private Inj2() {
+    }
+
     @Override
     public Either<Either<F, G2>, G> match(final Either<F, G> either) {
         return either.map(f -> Either.left(Either.left(f)), Either::right);
@@ -18,10 +23,5 @@ public final class Inj2<F, G, G2> implements Prism<Either<F, G>, Either<F, G2>, 
     @Override
     public String toString() {
         return "inj2";
-    }
-
-    @Override
-    public boolean equals(final Object obj) {
-        return obj instanceof Inj2<?, ?, ?>;
     }
 }

--- a/src/main/java/com/mojang/datafixers/optics/InjTagged.java
+++ b/src/main/java/com/mojang/datafixers/optics/InjTagged.java
@@ -37,4 +37,9 @@ public final class InjTagged<K, A, B> implements Prism<Pair<K, ?>, Pair<K, ?>, A
     public boolean equals(final Object obj) {
         return obj instanceof InjTagged<?, ?, ?> && Objects.equals(((InjTagged<?, ?, ?>) obj).key, key);
     }
+
+    @Override
+    public int hashCode() {
+        return key.hashCode();
+    }
 }

--- a/src/main/java/com/mojang/datafixers/optics/ListTraversal.java
+++ b/src/main/java/com/mojang/datafixers/optics/ListTraversal.java
@@ -11,6 +11,11 @@ import com.mojang.datafixers.kinds.K1;
 import java.util.List;
 
 public final class ListTraversal<A, B> implements Traversal<List<A>, List<B>, A, B> {
+    static final ListTraversal<?, ?> INSTANCE = new ListTraversal<>();
+
+    private ListTraversal() {
+    }
+
     @Override
     public <F extends K1> FunctionType<List<A>, App<F, List<B>>> wander(final Applicative<F, ?> applicative, final FunctionType<A, App<F, B>> input) {
         return as -> {
@@ -20,11 +25,6 @@ public final class ListTraversal<A, B> implements Traversal<List<A>, List<B>, A,
             }
             return applicative.map(ImmutableList.Builder::build, result);
         };
-    }
-
-    @Override
-    public boolean equals(final Object obj) {
-        return obj instanceof ListTraversal<?, ?>;
     }
 
     @Override

--- a/src/main/java/com/mojang/datafixers/optics/Optic.java
+++ b/src/main/java/com/mojang/datafixers/optics/Optic.java
@@ -41,7 +41,7 @@ public interface Optic<Proof extends K1, S, T, A, B> {
 
         @Override
         public String toString() {
-            return "(" + outer + " ◦ " + inner + ")";
+            return "(" + outer + " \u25E6 " + inner + ")";
         }
 
         @Override

--- a/src/main/java/com/mojang/datafixers/optics/Optic.java
+++ b/src/main/java/com/mojang/datafixers/optics/Optic.java
@@ -25,15 +25,7 @@ public interface Optic<Proof extends K1, S, T, A, B> {
         return new CompositionOptic<Proof2, S, T, A, B, A1, B1>((Optic<? super Proof2, S, T, A, B>) this, (Optic<? super Proof2, A, B, A1, B1>) optic);
     }
 
-    final class CompositionOptic<Proof extends K1, S, T, A, B, A1, B1> implements Optic<Proof, S, T, A1, B1> {
-        protected final Optic<? super Proof, S, T, A, B> outer;
-        protected final Optic<? super Proof, A, B, A1, B1> inner;
-
-        public CompositionOptic(final Optic<? super Proof, S, T, A, B> outer, final Optic<? super Proof, A, B, A1, B1> inner) {
-            this.outer = outer;
-            this.inner = inner;
-        }
-
+    record CompositionOptic<Proof extends K1, S, T, A, B, A1, B1>(Optic<? super Proof, S, T, A, B> outer, Optic<? super Proof, A, B, A1, B1> inner) implements Optic<Proof, S, T, A1, B1> {
         @Override
         public <P extends K2> Function<App2<P, A1, B1>, App2<P, S, T>> eval(final App<? extends Proof, P> proof) {
             return outer.eval(proof).compose(inner.eval(proof));
@@ -42,31 +34,6 @@ public interface Optic<Proof extends K1, S, T, A, B> {
         @Override
         public String toString() {
             return "(" + outer + " \u25E6 " + inner + ")";
-        }
-
-        @Override
-        public boolean equals(final Object o) {
-            if (this == o) {
-                return true;
-            }
-            if (o == null || getClass() != o.getClass()) {
-                return false;
-            }
-            final CompositionOptic<?, ?, ?, ?, ?, ?, ?> that = (CompositionOptic<?, ?, ?, ?, ?, ?, ?>) o;
-            return Objects.equals(outer, that.outer) && Objects.equals(inner, that.inner);
-        }
-
-        @Override
-        public int hashCode() {
-            return Objects.hash(outer, inner);
-        }
-
-        public Optic<? super Proof, S, T, A, B> outer() {
-            return outer;
-        }
-
-        public Optic<? super Proof, A, B, A1, B1> inner() {
-            return inner;
         }
     }
 

--- a/src/main/java/com/mojang/datafixers/optics/Optics.java
+++ b/src/main/java/com/mojang/datafixers/optics/Optics.java
@@ -64,8 +64,9 @@ public abstract class Optics {
         );
     }
 
+    @SuppressWarnings("unchecked")
     public static <S, T> Adapter<S, T, S, T> id() {
-        return new IdAdapter<>();
+        return (Adapter<S, T, S, T>) IdAdapter.INSTANCE;
     }
 
     public static <S, T, A, B> Adapter<S, T, A, B> adapter(final Function<S, A> from, final Function<B, T> to) {
@@ -222,20 +223,40 @@ public abstract class Optics {
         return FunctionType.unbox(box);
     }
 
+    @SuppressWarnings("unchecked")
     public static <F, G, F2> Proj1<F, G, F2> proj1() {
-        return new Proj1<>();
+        return (Proj1<F, G, F2>) Proj1.INSTANCE;
     }
 
+    public static boolean isProj1(final Optic<?, ?, ?, ?, ?> optic) {
+        return optic == Proj1.INSTANCE;
+    }
+
+    @SuppressWarnings("unchecked")
     public static <F, G, G2> Proj2<F, G, G2> proj2() {
-        return new Proj2<>();
+        return (Proj2<F, G, G2>) Proj2.INSTANCE;
     }
 
+    public static boolean isProj2(final Optic<?, ?, ?, ?, ?> optic) {
+        return optic == Proj2.INSTANCE;
+    }
+
+    @SuppressWarnings("unchecked")
     public static <F, G, F2> Inj1<F, G, F2> inj1() {
-        return new Inj1<>();
+        return (Inj1<F, G, F2>) Inj1.INSTANCE;
     }
 
+    public static boolean isInj1(final Optic<?, ?, ?, ?, ?> optic) {
+        return optic == Inj1.INSTANCE;
+    }
+
+    @SuppressWarnings("unchecked")
     public static <F, G, G2> Inj2<F, G, G2> inj2() {
-        return new Inj2<>();
+        return (Inj2<F, G, G2>) Inj2.INSTANCE;
+    }
+
+    public static boolean isInj2(final Optic<?, ?, ?, ?, ?> optic) {
+        return optic == Inj2.INSTANCE;
     }
 
     /*public static <Proof extends Cartesian.Mu, S1, S2, T1, T2, A, B> Optic<Proof, Either<S1, S2>, Either<T1, T2>, A, B> choosing(final Optic<? super Profunctor.Mu, S1, T1, A, B> first, final Optic<? super Profunctor.Mu, S2, T2, A, B> second) {
@@ -294,5 +315,10 @@ public abstract class Optics {
                 );
             }
         };
+    }
+
+    @SuppressWarnings("unchecked")
+    public static <A, B> ListTraversal<A, B> listTraversal() {
+        return (ListTraversal<A, B>) ListTraversal.INSTANCE;
     }
 }

--- a/src/main/java/com/mojang/datafixers/optics/Proj1.java
+++ b/src/main/java/com/mojang/datafixers/optics/Proj1.java
@@ -5,6 +5,11 @@ package com.mojang.datafixers.optics;
 import com.mojang.datafixers.util.Pair;
 
 public final class Proj1<F, G, F2> implements Lens<Pair<F, G>, Pair<F2, G>, F, F2> {
+    public static final Proj1<?, ?, ?> INSTANCE = new Proj1<>();
+
+    private Proj1() {
+    }
+
     @Override
     public F view(final Pair<F, G> pair) {
         return pair.getFirst();
@@ -18,10 +23,5 @@ public final class Proj1<F, G, F2> implements Lens<Pair<F, G>, Pair<F2, G>, F, F
     @Override
     public String toString() {
         return "\u03C01";
-    }
-
-    @Override
-    public boolean equals(final Object obj) {
-        return obj instanceof Proj1<?, ?, ?>;
     }
 }

--- a/src/main/java/com/mojang/datafixers/optics/Proj1.java
+++ b/src/main/java/com/mojang/datafixers/optics/Proj1.java
@@ -17,7 +17,7 @@ public final class Proj1<F, G, F2> implements Lens<Pair<F, G>, Pair<F2, G>, F, F
 
     @Override
     public String toString() {
-        return "π1";
+        return "\u03C01";
     }
 
     @Override

--- a/src/main/java/com/mojang/datafixers/optics/Proj2.java
+++ b/src/main/java/com/mojang/datafixers/optics/Proj2.java
@@ -17,7 +17,7 @@ public final class Proj2<F, G, G2> implements Lens<Pair<F, G>, Pair<F, G2>, G, G
 
     @Override
     public String toString() {
-        return "π2";
+        return "\u03C02";
     }
 
     @Override

--- a/src/main/java/com/mojang/datafixers/optics/Proj2.java
+++ b/src/main/java/com/mojang/datafixers/optics/Proj2.java
@@ -5,6 +5,11 @@ package com.mojang.datafixers.optics;
 import com.mojang.datafixers.util.Pair;
 
 public final class Proj2<F, G, G2> implements Lens<Pair<F, G>, Pair<F, G2>, G, G2> {
+    public static final Proj2<?, ?, ?> INSTANCE = new Proj2<>();
+
+    private Proj2() {
+    }
+
     @Override
     public G view(final Pair<F, G> pair) {
         return pair.getSecond();
@@ -18,10 +23,5 @@ public final class Proj2<F, G, G2> implements Lens<Pair<F, G>, Pair<F, G2>, G, G
     @Override
     public String toString() {
         return "\u03C02";
-    }
-
-    @Override
-    public boolean equals(final Object obj) {
-        return obj instanceof Proj2<?, ?, ?>;
     }
 }

--- a/src/main/java/com/mojang/datafixers/types/Func.java
+++ b/src/main/java/com/mojang/datafixers/types/Func.java
@@ -48,7 +48,9 @@ public final class Func<A, B> extends Type<Function<A, B>> {
 
     @Override
     public int hashCode() {
-        return Objects.hash(first, second);
+        int result = first.hashCode();
+        result = 31 * result + second.hashCode();
+        return result;
     }
 
     public Type<A> first() {

--- a/src/main/java/com/mojang/datafixers/types/Type.java
+++ b/src/main/java/com/mojang/datafixers/types/Type.java
@@ -57,7 +57,7 @@ public abstract class Type<A> implements App<Type.Mu, A> {
 
     @SuppressWarnings("unchecked")
     public static <S, T, A, B> RewriteResult<S, T> opticView(final Type<S> type, final RewriteResult<A, B> view, final TypedOptic<S, T, A, B> optic) {
-        if (Objects.equals(view.view().function(), Functions.id())) {
+        if (Functions.isId(view.view().function())) {
             return (RewriteResult<S, T>) RewriteResult.nop(type);
         }
         // copy the recData, since optic doesn't touch more than the nested view

--- a/src/main/java/com/mojang/datafixers/types/Type.java
+++ b/src/main/java/com/mojang/datafixers/types/Type.java
@@ -57,7 +57,7 @@ public abstract class Type<A> implements App<Type.Mu, A> {
 
     @SuppressWarnings("unchecked")
     public static <S, T, A, B> RewriteResult<S, T> opticView(final Type<S> type, final RewriteResult<A, B> view, final TypedOptic<S, T, A, B> optic) {
-        if (Functions.isId(view.view().function())) {
+        if (view.view().isNop()) {
             return (RewriteResult<S, T>) RewriteResult.nop(type);
         }
         // copy the recData, since optic doesn't touch more than the nested view

--- a/src/main/java/com/mojang/datafixers/types/Type.java
+++ b/src/main/java/com/mojang/datafixers/types/Type.java
@@ -31,7 +31,6 @@ import org.apache.commons.lang3.tuple.Triple;
 
 import javax.annotation.Nullable;
 import java.util.Map;
-import java.util.Objects;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 
@@ -151,7 +150,7 @@ public abstract class Type<A> implements App<Type.Mu, A> {
     public <T> DataResult<T> readAndWrite(final DynamicOps<T> ops, final Type<?> expectedType, final TypeRewriteRule rule, final PointFreeRule fRule, final T input) {
         final Optional<RewriteResult<A, ?>> rewriteResult = rewrite(rule, fRule);
         if (!rewriteResult.isPresent()) {
-            return DataResult.error("Could not build a rewrite rule: " + rule + " " + fRule, input);
+            return DataResult.error(() -> "Could not build a rewrite rule: " + rule + " " + fRule, input);
         }
         final View<A, ?> view = rewriteResult.get().view();
         if (view.isNop()) {
@@ -165,7 +164,7 @@ public abstract class Type<A> implements App<Type.Mu, A> {
 
     private <T, B> DataResult<T> capWrite(final DynamicOps<T> ops, final Type<?> expectedType, final T rest, final A value, final View<A, B> f) {
         if (!expectedType.equals(f.newType(), true, true)) {
-            return DataResult.error("Rewritten type doesn't match");
+            return DataResult.error(() -> "Rewritten type doesn't match");
         }
         return f.newType().codec().encode(f.function().evalCached().apply(ops).apply(value), ops, rest);
     }

--- a/src/main/java/com/mojang/datafixers/types/Type.java
+++ b/src/main/java/com/mojang/datafixers/types/Type.java
@@ -154,6 +154,9 @@ public abstract class Type<A> implements App<Type.Mu, A> {
             return DataResult.error("Could not build a rewrite rule: " + rule + " " + fRule, input);
         }
         final View<A, ?> view = rewriteResult.get().view();
+        if (view.isNop()) {
+            return DataResult.success(input);
+        }
 
         return codec().decode(ops, input).flatMap(pair ->
             capWrite(ops, expectedType, pair.getSecond(), pair.getFirst(), view)

--- a/src/main/java/com/mojang/datafixers/types/families/RecursiveTypeFamily.java
+++ b/src/main/java/com/mojang/datafixers/types/families/RecursiveTypeFamily.java
@@ -16,7 +16,6 @@ import com.mojang.datafixers.functions.Functions;
 import com.mojang.datafixers.functions.PointFree;
 import com.mojang.datafixers.functions.PointFreeRule;
 import com.mojang.datafixers.optics.Optic;
-import com.mojang.datafixers.types.Func;
 import com.mojang.datafixers.types.Type;
 import com.mojang.datafixers.types.templates.RecursivePoint;
 import com.mojang.datafixers.types.templates.TypeTemplate;
@@ -166,7 +165,7 @@ public final class RecursiveTypeFamily implements TypeFamily {
             boolean nop1 = true;
             // FB -> GB
             final RewriteResult<?, ?> view = DataFixUtils.orElse(unfold.everywhere(rule, optimizationRule, false, true), RewriteResult.nop(unfold));
-            if (!Functions.isId(view.view().function())) {
+            if (!view.view().isNop()) {
                 nop1 = false;
             }
 
@@ -187,7 +186,7 @@ public final class RecursiveTypeFamily implements TypeFamily {
         final RewriteResult<A, B> newView = RewriteResult.create(newType.in(), new BitSet()).compose((RewriteResult<A, B>) view);
         // B -> B
         final Optional<RewriteResult<B, ?>> rewrite = rule.rewrite(newView.view().newType());
-        if (rewrite.isPresent() && !Functions.isId(rewrite.get().view().function())) {
+        if (rewrite.isPresent() && !rewrite.get().view().isNop()) {
             nop = false;
             view = rewrite.get().compose((RewriteResult<A, B>) newView);
         }

--- a/src/main/java/com/mojang/datafixers/types/families/RecursiveTypeFamily.java
+++ b/src/main/java/com/mojang/datafixers/types/families/RecursiveTypeFamily.java
@@ -14,6 +14,7 @@ import com.mojang.datafixers.functions.Functions;
 import com.mojang.datafixers.functions.PointFree;
 import com.mojang.datafixers.functions.PointFreeRule;
 import com.mojang.datafixers.optics.Optic;
+import com.mojang.datafixers.types.Func;
 import com.mojang.datafixers.types.Type;
 import com.mojang.datafixers.types.templates.RecursivePoint;
 import com.mojang.datafixers.types.templates.TypeTemplate;
@@ -161,7 +162,7 @@ public final class RecursiveTypeFamily implements TypeFamily {
             boolean nop1 = true;
             // FB -> GB
             final RewriteResult<?, ?> view = DataFixUtils.orElse(unfold.everywhere(rule, optimizationRule, false, true), RewriteResult.nop(unfold));
-            if (!Objects.equals(view.view().function(), Functions.id())) {
+            if (!Functions.isId(view.view().function())) {
                 nop1 = false;
             }
 
@@ -182,7 +183,7 @@ public final class RecursiveTypeFamily implements TypeFamily {
         final RewriteResult<A, B> newView = RewriteResult.create(newType.in(), new BitSet()).compose((RewriteResult<A, B>) view);
         // B -> B
         final Optional<RewriteResult<B, ?>> rewrite = rule.rewrite(newView.view().newType());
-        if (rewrite.isPresent() && !Objects.equals(rewrite.get().view().function(), Functions.id())) {
+        if (rewrite.isPresent() && !Functions.isId(rewrite.get().view().function())) {
             nop = false;
             view = rewrite.get().compose((RewriteResult<A, B>) newView);
         }

--- a/src/main/java/com/mojang/datafixers/types/families/RecursiveTypeFamily.java
+++ b/src/main/java/com/mojang/datafixers/types/families/RecursiveTypeFamily.java
@@ -2,6 +2,8 @@
 // Licensed under the MIT license.
 package com.mojang.datafixers.types.families;
 
+import com.google.common.collect.Interner;
+import com.google.common.collect.Interners;
 import com.google.common.collect.Lists;
 import com.mojang.datafixers.DataFixUtils;
 import com.mojang.datafixers.FamilyOptic;
@@ -32,6 +34,8 @@ import java.util.function.Function;
 import java.util.function.IntFunction;
 
 public final class RecursiveTypeFamily implements TypeFamily {
+    private static final Interner<TypeTemplate> TEMPLATE_INTERNER = Interners.newWeakInterner();
+
     private final String name;
     private final TypeTemplate template;
     private final int size;
@@ -41,7 +45,7 @@ public final class RecursiveTypeFamily implements TypeFamily {
 
     public RecursiveTypeFamily(final String name, final TypeTemplate template) {
         this.name = name;
-        this.template = template;
+        this.template = TEMPLATE_INTERNER.intern(template);
         size = template.size();
         hashCode = Objects.hashCode(template);
     }
@@ -57,7 +61,7 @@ public final class RecursiveTypeFamily implements TypeFamily {
             // G
             final TypeTemplate newTypeTemplate = newType.template();
             // Mu G
-            if (Objects.equals(template, newTypeTemplate)) {
+            if (template == newTypeTemplate) {
                 newFamily = this;
             } else {
                 newFamily = new RecursiveTypeFamily("ruled " + name, newTypeTemplate);
@@ -206,7 +210,7 @@ public final class RecursiveTypeFamily implements TypeFamily {
             return false;
         }
         final RecursiveTypeFamily family = (RecursiveTypeFamily) o;
-        return Objects.equals(template, family.template);
+        return template == family.template;
     }
 
     @Override

--- a/src/main/java/com/mojang/datafixers/types/templates/Check.java
+++ b/src/main/java/com/mojang/datafixers/types/templates/Check.java
@@ -133,7 +133,7 @@ public final class Check implements TypeTemplate {
 
         private <T> DataResult<Pair<A, T>> read(final DynamicOps<T> ops, final T input) {
             if (index != expectedIndex) {
-                return DataResult.error("Index mismatch: " + index + " != " + expectedIndex);
+                return DataResult.error(() -> "Index mismatch: " + index + " != " + expectedIndex);
             }
             return delegate.codec().decode(ops, input);
         }

--- a/src/main/java/com/mojang/datafixers/types/templates/Check.java
+++ b/src/main/java/com/mojang/datafixers/types/templates/Check.java
@@ -7,7 +7,6 @@ import com.mojang.datafixers.FamilyOptic;
 import com.mojang.datafixers.RewriteResult;
 import com.mojang.datafixers.TypeRewriteRule;
 import com.mojang.datafixers.TypedOptic;
-import com.mojang.datafixers.functions.Functions;
 import com.mojang.datafixers.functions.PointFreeRule;
 import com.mojang.datafixers.types.Func;
 import com.mojang.datafixers.types.Type;
@@ -140,7 +139,7 @@ public final class Check implements TypeTemplate {
         }
 
         public static <A, B> RewriteResult<A, ?> fix(final CheckType<A> type, final RewriteResult<A, B> instance) {
-            if (Functions.isId(instance.view().function())) {
+            if (instance.view().isNop()) {
                 return RewriteResult.nop(type);
             }
             return opticView(type, instance, wrapOptic(type, TypedOptic.adapter(instance.view().type(), instance.view().newType())));

--- a/src/main/java/com/mojang/datafixers/types/templates/Check.java
+++ b/src/main/java/com/mojang/datafixers/types/templates/Check.java
@@ -9,6 +9,7 @@ import com.mojang.datafixers.TypeRewriteRule;
 import com.mojang.datafixers.TypedOptic;
 import com.mojang.datafixers.functions.Functions;
 import com.mojang.datafixers.functions.PointFreeRule;
+import com.mojang.datafixers.types.Func;
 import com.mojang.datafixers.types.Type;
 import com.mojang.datafixers.types.families.RecursiveTypeFamily;
 import com.mojang.datafixers.types.families.TypeFamily;
@@ -136,7 +137,7 @@ public final class Check implements TypeTemplate {
         }
 
         public static <A, B> RewriteResult<A, ?> fix(final CheckType<A> type, final RewriteResult<A, B> instance) {
-            if (Objects.equals(instance.view().function(), Functions.id())) {
+            if (Functions.isId(instance.view().function())) {
                 return RewriteResult.nop(type);
             }
             return opticView(type, instance, wrapOptic(type, TypedOptic.adapter(instance.view().type(), instance.view().newType())));

--- a/src/main/java/com/mojang/datafixers/types/templates/Check.java
+++ b/src/main/java/com/mojang/datafixers/types/templates/Check.java
@@ -100,7 +100,10 @@ public final class Check implements TypeTemplate {
 
     @Override
     public int hashCode() {
-        return Objects.hash(name, index, element);
+        int result = name.hashCode();
+        result = 31 * result + index;
+        result = 31 * result + element.hashCode();
+        return result;
     }
 
     @Override
@@ -249,7 +252,10 @@ public final class Check implements TypeTemplate {
 
         @Override
         public int hashCode() {
-            return Objects.hash(index, expectedIndex, delegate);
+            int result = index;
+            result = 31 * result + expectedIndex;
+            result = 31 * result + delegate.hashCode();
+            return result;
         }
     }
 }

--- a/src/main/java/com/mojang/datafixers/types/templates/CompoundList.java
+++ b/src/main/java/com/mojang/datafixers/types/templates/CompoundList.java
@@ -64,7 +64,7 @@ public final class CompoundList implements TypeTemplate {
     }
 
     private <S, T, A, B> Optic<?, ?, ?, A, B> cap(final Optic<?, S, T, A, B> concreteOptic) {
-        return new ListTraversal<Pair<String, S>, Pair<String, T>>().compose(Optics.proj2()).composeUnchecked(concreteOptic);
+        return Optics.<Pair<String, S>, Pair<String, T>>listTraversal().compose(Optics.proj2()).composeUnchecked(concreteOptic);
     }
 
     @Override

--- a/src/main/java/com/mojang/datafixers/types/templates/CompoundList.java
+++ b/src/main/java/com/mojang/datafixers/types/templates/CompoundList.java
@@ -92,7 +92,7 @@ public final class CompoundList implements TypeTemplate {
 
     @Override
     public int hashCode() {
-        return Objects.hash(element);
+        return element.hashCode();
     }
 
     @Override
@@ -192,7 +192,9 @@ public final class CompoundList implements TypeTemplate {
 
         @Override
         public int hashCode() {
-            return Objects.hash(key, element);
+            int result = key.hashCode();
+            result = 31 * result + element.hashCode();
+            return result;
         }
 
         public Type<K> getKey() {

--- a/src/main/java/com/mojang/datafixers/types/templates/Const.java
+++ b/src/main/java/com/mojang/datafixers/types/templates/Const.java
@@ -84,7 +84,7 @@ public final class Const implements TypeTemplate {
 
     @Override
     public int hashCode() {
-        return Objects.hash(type);
+        return type.hashCode();
     }
 
     @Override

--- a/src/main/java/com/mojang/datafixers/types/templates/Hook.java
+++ b/src/main/java/com/mojang/datafixers/types/templates/Hook.java
@@ -7,7 +7,6 @@ import com.mojang.datafixers.FamilyOptic;
 import com.mojang.datafixers.RewriteResult;
 import com.mojang.datafixers.TypeRewriteRule;
 import com.mojang.datafixers.TypedOptic;
-import com.mojang.datafixers.functions.Functions;
 import com.mojang.datafixers.types.Type;
 import com.mojang.datafixers.types.families.RecursiveTypeFamily;
 import com.mojang.datafixers.types.families.TypeFamily;
@@ -174,7 +173,7 @@ public final class Hook implements TypeTemplate {
         }
 
         public static <A, B> RewriteResult<A, ?> fix(final HookType<A> type, final RewriteResult<A, B> instance) {
-            if (Functions.isId(instance.view().function())) {
+            if (instance.view().isNop()) {
                 return RewriteResult.nop(type);
             }
             return opticView(type, instance, wrapOptic(TypedOptic.adapter(instance.view().type(), instance.view().newType()), type.preRead, type.postWrite));

--- a/src/main/java/com/mojang/datafixers/types/templates/Hook.java
+++ b/src/main/java/com/mojang/datafixers/types/templates/Hook.java
@@ -171,7 +171,7 @@ public final class Hook implements TypeTemplate {
         }
 
         public static <A, B> RewriteResult<A, ?> fix(final HookType<A> type, final RewriteResult<A, B> instance) {
-            if (Objects.equals(instance.view().function(), Functions.id())) {
+            if (Functions.isId(instance.view().function())) {
                 return RewriteResult.nop(type);
             }
             return opticView(type, instance, wrapOptic(TypedOptic.adapter(instance.view().type(), instance.view().newType()), type.preRead, type.postWrite));

--- a/src/main/java/com/mojang/datafixers/types/templates/Hook.java
+++ b/src/main/java/com/mojang/datafixers/types/templates/Hook.java
@@ -91,7 +91,10 @@ public final class Hook implements TypeTemplate {
 
     @Override
     public int hashCode() {
-        return Objects.hash(element, preRead, postWrite);
+        int result = element.hashCode();
+        result = 31 * result + preRead.hashCode();
+        result = 31 * result + postWrite.hashCode();
+        return result;
     }
 
     @Override
@@ -204,7 +207,10 @@ public final class Hook implements TypeTemplate {
 
         @Override
         public int hashCode() {
-            return Objects.hash(delegate, preRead, postWrite);
+            int result = delegate.hashCode();
+            result = 31 * result + preRead.hashCode();
+            result = 31 * result + postWrite.hashCode();
+            return result;
         }
     }
 }

--- a/src/main/java/com/mojang/datafixers/types/templates/List.java
+++ b/src/main/java/com/mojang/datafixers/types/templates/List.java
@@ -101,7 +101,7 @@ public final class List implements TypeTemplate {
 
     @Override
     public int hashCode() {
-        return Objects.hash(element);
+        return element.hashCode();
     }
 
     @Override

--- a/src/main/java/com/mojang/datafixers/types/templates/List.java
+++ b/src/main/java/com/mojang/datafixers/types/templates/List.java
@@ -14,6 +14,7 @@ import com.mojang.datafixers.TypedOptic;
 import com.mojang.datafixers.kinds.K1;
 import com.mojang.datafixers.optics.ListTraversal;
 import com.mojang.datafixers.optics.Optic;
+import com.mojang.datafixers.optics.Optics;
 import com.mojang.datafixers.optics.profunctors.TraversalP;
 import com.mojang.datafixers.types.Type;
 import com.mojang.datafixers.types.families.RecursiveTypeFamily;
@@ -73,7 +74,7 @@ public final class List implements TypeTemplate {
     }
 
     private <S, T, A, B> Optic<?, ?, ?, A, B> cap(final Optic<?, S, T, A, B> concreteOptic) {
-        return new ListTraversal<S, T>().composeUnchecked(concreteOptic);
+        return Optics.<S, T>listTraversal().composeUnchecked(concreteOptic);
     }
 
     @Override

--- a/src/main/java/com/mojang/datafixers/types/templates/Named.java
+++ b/src/main/java/com/mojang/datafixers/types/templates/Named.java
@@ -9,7 +9,6 @@ import com.mojang.datafixers.FamilyOptic;
 import com.mojang.datafixers.RewriteResult;
 import com.mojang.datafixers.TypeRewriteRule;
 import com.mojang.datafixers.TypedOptic;
-import com.mojang.datafixers.functions.Functions;
 import com.mojang.datafixers.kinds.K1;
 import com.mojang.datafixers.optics.Optics;
 import com.mojang.datafixers.optics.profunctors.Cartesian;
@@ -103,7 +102,7 @@ public final class Named implements TypeTemplate {
         }
 
         public static <A, B> RewriteResult<Pair<String, A>, ?> fix(final NamedType<A> type, final RewriteResult<A, B> instance) {
-            if (Functions.isId(instance.view().function())) {
+            if (instance.view().isNop()) {
                 return RewriteResult.nop(type);
             }
             return opticView(type, instance, wrapOptic(type.name, TypedOptic.adapter(instance.view().type(), instance.view().newType())));

--- a/src/main/java/com/mojang/datafixers/types/templates/Named.java
+++ b/src/main/java/com/mojang/datafixers/types/templates/Named.java
@@ -101,7 +101,7 @@ public final class Named implements TypeTemplate {
         }
 
         public static <A, B> RewriteResult<Pair<String, A>, ?> fix(final NamedType<A> type, final RewriteResult<A, B> instance) {
-            if (Objects.equals(instance.view().function(), Functions.id())) {
+            if (Functions.isId(instance.view().function())) {
                 return RewriteResult.nop(type);
             }
             return opticView(type, instance, wrapOptic(type.name, TypedOptic.adapter(instance.view().type(), instance.view().newType())));

--- a/src/main/java/com/mojang/datafixers/types/templates/Named.java
+++ b/src/main/java/com/mojang/datafixers/types/templates/Named.java
@@ -83,7 +83,9 @@ public final class Named implements TypeTemplate {
 
     @Override
     public int hashCode() {
-        return Objects.hash(name, element);
+        int result = name.hashCode();
+        result = 31 * result + element.hashCode();
+        return result;
     }
 
     @Override
@@ -184,7 +186,9 @@ public final class Named implements TypeTemplate {
 
         @Override
         public int hashCode() {
-            return Objects.hash(name, element);
+            int result = name.hashCode();
+            result = 31 * result + element.hashCode();
+            return result;
         }
 
         @Override

--- a/src/main/java/com/mojang/datafixers/types/templates/Named.java
+++ b/src/main/java/com/mojang/datafixers/types/templates/Named.java
@@ -151,7 +151,7 @@ public final class Named implements TypeTemplate {
                 @Override
                 public <T> DataResult<T> encode(final Pair<String, A> input, final DynamicOps<T> ops, final T prefix) {
                     if (!Objects.equals(input.getFirst(), name)) {
-                        return DataResult.error("Named type name doesn't match: expected: " + name + ", got: " + input.getFirst(), prefix);
+                        return DataResult.error(() -> "Named type name doesn't match: expected: " + name + ", got: " + input.getFirst(), prefix);
                     }
                     return element.codec().encode(input.getSecond(), ops, prefix).setLifecycle(Lifecycle.experimental());
                 }

--- a/src/main/java/com/mojang/datafixers/types/templates/Product.java
+++ b/src/main/java/com/mojang/datafixers/types/templates/Product.java
@@ -146,7 +146,9 @@ public final class Product implements TypeTemplate {
 
     @Override
     public int hashCode() {
-        return Objects.hash(f, g);
+        int result = f.hashCode();
+        result = 31 * result + g.hashCode();
+        return result;
     }
 
     @Override
@@ -233,7 +235,9 @@ public final class Product implements TypeTemplate {
         @Override
         public int hashCode() {
             if (hashCode == 0) {
-                hashCode = Objects.hash(first, second);
+                int result = first.hashCode();
+                result = 31 * result + second.hashCode();
+                hashCode = result;
             }
             return hashCode;
         }

--- a/src/main/java/com/mojang/datafixers/types/templates/RecursivePoint.java
+++ b/src/main/java/com/mojang/datafixers/types/templates/RecursivePoint.java
@@ -98,7 +98,7 @@ public final class RecursivePoint implements TypeTemplate {
 
     @Override
     public int hashCode() {
-        return Objects.hash(index);
+        return index;
     }
 
     @Override
@@ -276,7 +276,9 @@ public final class RecursivePoint implements TypeTemplate {
 
         @Override
         public int hashCode() {
-            return Objects.hash(family, index);
+            int result = family.hashCode();
+            result = 31 * result + index;
+            return result;
         }
 
         public View<A, A> in() {

--- a/src/main/java/com/mojang/datafixers/types/templates/Sum.java
+++ b/src/main/java/com/mojang/datafixers/types/templates/Sum.java
@@ -145,7 +145,9 @@ public final class Sum implements TypeTemplate {
 
     @Override
     public int hashCode() {
-        return Objects.hash(f, g);
+        int result = f.hashCode();
+        result = 31 * result + g.hashCode();
+        return result;
     }
 
     @Override
@@ -232,7 +234,9 @@ public final class Sum implements TypeTemplate {
         @Override
         public int hashCode() {
             if (hashCode == 0) {
-                hashCode = Objects.hash(first, second);
+                int result = first.hashCode();
+                result = 31 * result + second.hashCode();
+                hashCode = result;
             }
             return hashCode;
         }

--- a/src/main/java/com/mojang/datafixers/types/templates/Tag.java
+++ b/src/main/java/com/mojang/datafixers/types/templates/Tag.java
@@ -122,7 +122,9 @@ public final class Tag implements TypeTemplate {
 
     @Override
     public int hashCode() {
-        return Objects.hash(name, element);
+        int result = name.hashCode();
+        result = 31 * result + element.hashCode();
+        return result;
     }
 
     @Override
@@ -192,7 +194,9 @@ public final class Tag implements TypeTemplate {
 
         @Override
         public int hashCode() {
-            return Objects.hash(name, element);
+            int result = name.hashCode();
+            result = 31 * result + element.hashCode();
+            return result;
         }
 
         @Override

--- a/src/main/java/com/mojang/datafixers/types/templates/Tag.java
+++ b/src/main/java/com/mojang/datafixers/types/templates/Tag.java
@@ -146,7 +146,7 @@ public final class Tag implements TypeTemplate {
         }
 
         private <B> View<A, ?> cap(final View<A, B> instance) {
-            if (Objects.equals(instance.function(), Functions.id())) {
+            if (Functions.isId(instance.function())) {
                 return View.nopView(this);
             }
             return View.create(this, DSL.field(name, instance.newType()), instance.function());

--- a/src/main/java/com/mojang/datafixers/types/templates/Tag.java
+++ b/src/main/java/com/mojang/datafixers/types/templates/Tag.java
@@ -8,7 +8,6 @@ import com.mojang.datafixers.RewriteResult;
 import com.mojang.datafixers.TypeRewriteRule;
 import com.mojang.datafixers.TypedOptic;
 import com.mojang.datafixers.View;
-import com.mojang.datafixers.functions.Functions;
 import com.mojang.datafixers.types.Type;
 import com.mojang.datafixers.types.families.RecursiveTypeFamily;
 import com.mojang.datafixers.types.families.TypeFamily;
@@ -148,7 +147,7 @@ public final class Tag implements TypeTemplate {
         }
 
         private <B> View<A, ?> cap(final View<A, B> instance) {
-            if (Functions.isId(instance.function())) {
+            if (instance.isNop()) {
                 return View.nopView(this);
             }
             return View.create(this, DSL.field(name, instance.newType()), instance.function());

--- a/src/main/java/com/mojang/datafixers/types/templates/TaggedChoice.java
+++ b/src/main/java/com/mojang/datafixers/types/templates/TaggedChoice.java
@@ -116,7 +116,10 @@ public final class TaggedChoice<K> implements TypeTemplate {
 
     @Override
     public int hashCode() {
-        return Objects.hash(name, keyType, templates);
+        int result = name.hashCode();
+        result = 31 * result + keyType.hashCode();
+        result = 31 * result + templates.hashCode();
+        return result;
     }
 
     @Override
@@ -463,7 +466,7 @@ public final class TaggedChoice<K> implements TypeTemplate {
 
             @Override
             public int hashCode() {
-                return Objects.hash(results);
+                return results.hashCode();
             }
         }
     }

--- a/src/main/java/com/mojang/datafixers/types/templates/TaggedChoice.java
+++ b/src/main/java/com/mojang/datafixers/types/templates/TaggedChoice.java
@@ -215,7 +215,7 @@ public final class TaggedChoice<K> implements TypeTemplate {
         }
 
         private DataResult<? extends Codec<?>> getCodec(final K k) {
-            return Optional.ofNullable(types.get(k)).map(t -> DataResult.success(t.codec())).orElseGet(() -> DataResult.error("Unsupported key: " + k));
+            return Optional.ofNullable(types.get(k)).map(t -> DataResult.success(t.codec())).orElseGet(() -> DataResult.error(() -> "Unsupported key: " + k));
         }
 
         @Override

--- a/src/main/java/com/mojang/datafixers/types/templates/TaggedChoice.java
+++ b/src/main/java/com/mojang/datafixers/types/templates/TaggedChoice.java
@@ -145,7 +145,7 @@ public final class TaggedChoice<K> implements TypeTemplate {
             final Object2ObjectMap<K, RewriteResult<?, ?>> results = new Object2ObjectOpenHashMap<>(types.size());
             for (final Map.Entry<K, Type<?>> entry : Object2ObjectMaps.fastIterable(types)) {
                 final Optional<? extends RewriteResult<?, ?>> result = rule.rewrite(entry.getValue());
-                if (result.isPresent() && !Functions.isId(result.get().view().function())) {
+                if (result.isPresent() && !result.get().view().isNop()) {
                     results.put(entry.getKey(), result.get());
                 }
             }

--- a/src/main/java/com/mojang/datafixers/types/templates/TaggedChoice.java
+++ b/src/main/java/com/mojang/datafixers/types/templates/TaggedChoice.java
@@ -134,7 +134,7 @@ public final class TaggedChoice<K> implements TypeTemplate {
         public RewriteResult<Pair<K, ?>, ?> all(final TypeRewriteRule rule, final boolean recurse, final boolean checkIndex) {
             final Map<K, ? extends RewriteResult<?, ?>> results = types.entrySet().stream()
                 .map(e -> rule.rewrite(e.getValue()).map(v -> Pair.of(e.getKey(), v)))
-                .filter(e -> e.isPresent() && !Objects.equals(e.get().getSecond().view().function(), Functions.id()))
+                .filter(e -> e.isPresent() && !Functions.isId(e.get().getSecond().view().function()))
                 .map(Optional::get)
                 .collect(Pair.toMap())
                 ;

--- a/src/main/java/com/mojang/datafixers/util/Either.java
+++ b/src/main/java/com/mojang/datafixers/util/Either.java
@@ -78,7 +78,7 @@ public abstract class Either<L, R> implements App<Either.Mu<R>, L> {
 
         @Override
         public int hashCode() {
-            return Objects.hash(value);
+            return value.hashCode();
         }
     }
 
@@ -139,7 +139,7 @@ public abstract class Either<L, R> implements App<Either.Mu<R>, L> {
 
         @Override
         public int hashCode() {
-            return Objects.hash(value);
+            return value.hashCode();
         }
     }
 

--- a/src/main/java/com/mojang/serialization/Codec.java
+++ b/src/main/java/com/mojang/serialization/Codec.java
@@ -351,7 +351,7 @@ public interface Codec<A> extends Encoder<A>, Decoder<A> {
             if (value.compareTo(minInclusive) >= 0 && value.compareTo(maxInclusive) <= 0) {
                 return DataResult.success(value);
             }
-            return DataResult.error("Value " + value + " outside of range [" + minInclusive + ":" + maxInclusive + "]", value);
+            return DataResult.error(() -> "Value " + value + " outside of range [" + minInclusive + ":" + maxInclusive + "]", value);
         };
     }
 
@@ -597,7 +597,7 @@ public interface Codec<A> extends Encoder<A>, Decoder<A> {
             return toMap.result().map(DataResult::success).orElseGet(() -> {
                 final DataResult<T> toList = ops.getStream(casted).flatMap(stream -> ops.mergeToList(prefix, stream.collect(Collectors.toList())));
                 return toList.result().map(DataResult::success).orElseGet(() ->
-                    DataResult.error("Don't know how to merge " + prefix + " and " + casted, prefix, Lifecycle.experimental())
+                    DataResult.error(() -> "Don't know how to merge " + prefix + " and " + casted, prefix, Lifecycle.experimental())
                 );
             });
         }

--- a/src/main/java/com/mojang/serialization/DataResult.java
+++ b/src/main/java/com/mojang/serialization/DataResult.java
@@ -34,14 +34,6 @@ public class DataResult<R> implements App<DataResult.Mu, R> {
         return success(result, Lifecycle.experimental());
     }
 
-    public static <R> DataResult<R> error(final String message, final R partialResult) {
-        return error(() -> message, partialResult);
-    }
-
-    public static <R> DataResult<R> error(final String message) {
-        return error(() -> message);
-    }
-
     public static <R> DataResult<R> error(final Supplier<String> message, final R partialResult) {
         return error(message, partialResult, Lifecycle.experimental());
     }
@@ -52,14 +44,6 @@ public class DataResult<R> implements App<DataResult.Mu, R> {
 
     public static <R> DataResult<R> success(final R result, final Lifecycle experimental) {
         return new DataResult<>(Either.left(result), experimental);
-    }
-
-    public static <R> DataResult<R> error(final String message, final R partialResult, final Lifecycle lifecycle) {
-        return error(() -> message, partialResult, lifecycle);
-    }
-
-    public static <R> DataResult<R> error(final String message, final Lifecycle lifecycle) {
-        return error(() -> message, lifecycle);
     }
 
     public static <R> DataResult<R> error(final Supplier<String> message, final R partialResult, final Lifecycle lifecycle) {

--- a/src/main/java/com/mojang/serialization/DataResult.java
+++ b/src/main/java/com/mojang/serialization/DataResult.java
@@ -220,7 +220,7 @@ public class DataResult<R> implements App<DataResult.Mu, R> {
 
     @Override
     public int hashCode() {
-        return Objects.hash(result);
+        return result.hashCode();
     }
 
     @Override
@@ -267,7 +267,9 @@ public class DataResult<R> implements App<DataResult.Mu, R> {
 
         @Override
         public int hashCode() {
-            return Objects.hash(message, partialResult);
+            int result = message.hashCode();
+            result = 31 * result + partialResult.hashCode();
+            return result;
         }
 
         @Override

--- a/src/main/java/com/mojang/serialization/Decoder.java
+++ b/src/main/java/com/mojang/serialization/Decoder.java
@@ -137,7 +137,7 @@ public interface Decoder<A> {
         return new Decoder<A>() {
             @Override
             public <T> DataResult<Pair<A, T>> decode(final DynamicOps<T> ops, final T input) {
-                return DataResult.error(error);
+                return DataResult.error(() -> error);
             }
 
             @Override

--- a/src/main/java/com/mojang/serialization/Dynamic.java
+++ b/src/main/java/com/mojang/serialization/Dynamic.java
@@ -164,7 +164,9 @@ public class Dynamic<T> extends DynamicLike<T> {
 
     @Override
     public int hashCode() {
-        return Objects.hash(ops, value);
+        int result = value.hashCode();
+        result = 31 * result + ops.hashCode();
+        return result;
     }
 
     @Override

--- a/src/main/java/com/mojang/serialization/Dynamic.java
+++ b/src/main/java/com/mojang/serialization/Dynamic.java
@@ -113,7 +113,7 @@ public class Dynamic<T> extends DynamicLike<T> {
         return new OptionalDynamic<>(ops, ops.getMap(value).flatMap(m -> {
             final T value = m.get(key);
             if (value == null) {
-                return DataResult.error("key missing: " + key + " in " + this.value);
+                return DataResult.error(() -> "key missing: " + key + " in " + this.value);
             }
             return DataResult.success(new Dynamic<>(ops, value));
         }));

--- a/src/main/java/com/mojang/serialization/DynamicOps.java
+++ b/src/main/java/com/mojang/serialization/DynamicOps.java
@@ -114,7 +114,7 @@ public interface DynamicOps<T> {
      */
     default DataResult<T> mergeToPrimitive(final T prefix, final T value) {
         if (!Objects.equals(prefix, empty())) {
-            return DataResult.error("Do not know how to append a primitive value " + value + " to " + prefix, value);
+            return DataResult.error(() -> "Do not know how to append a primitive value " + value + " to " + prefix, value);
         }
         return DataResult.success(value);
     }
@@ -132,7 +132,7 @@ public interface DynamicOps<T> {
             try {
                 return DataResult.success(MapLike.forMap(s.collect(Pair.toMap()), this));
             } catch (final IllegalStateException e) {
-                return DataResult.error("Error while building map: " + e.getMessage());
+                return DataResult.error(() -> "Error while building map: " + e.getMessage());
             }
         });
     }
@@ -159,7 +159,7 @@ public interface DynamicOps<T> {
                 }
                 return DataResult.success(buffer);
             }
-            return DataResult.error("Some elements are not bytes: " + input);
+            return DataResult.error(() -> "Some elements are not bytes: " + input);
         });
     }
 
@@ -173,7 +173,7 @@ public interface DynamicOps<T> {
             if (list.stream().allMatch(element -> getNumberValue(element).result().isPresent())) {
                 return DataResult.success(list.stream().mapToInt(element -> getNumberValue(element).result().get().intValue()));
             }
-            return DataResult.error("Some elements are not ints: " + input);
+            return DataResult.error(() -> "Some elements are not ints: " + input);
         });
     }
 
@@ -187,7 +187,7 @@ public interface DynamicOps<T> {
             if (list.stream().allMatch(element -> getNumberValue(element).result().isPresent())) {
                 return DataResult.success(list.stream().mapToLong(element -> getNumberValue(element).result().get().longValue()));
             }
-            return DataResult.error("Some elements are not longs: " + input);
+            return DataResult.error(() -> "Some elements are not longs: " + input);
         });
     }
 
@@ -208,7 +208,7 @@ public interface DynamicOps<T> {
     default DataResult<T> getGeneric(final T input, final T key) {
         return getMap(input).flatMap(map -> Optional.ofNullable(map.get(key))
             .map(DataResult::success)
-            .orElseGet(() -> DataResult.error("No element " + key + " in the map " + input))
+            .orElseGet(() -> DataResult.error(() -> "No element " + key + " in the map " + input))
         );
     }
 

--- a/src/main/java/com/mojang/serialization/Encoder.java
+++ b/src/main/java/com/mojang/serialization/Encoder.java
@@ -83,7 +83,7 @@ public interface Encoder<A> {
         return new Encoder<A>() {
             @Override
             public <T> DataResult<T> encode(final A input, final DynamicOps<T> ops, final T prefix) {
-                return DataResult.error(error + " " + input);
+                return DataResult.error(() -> error + " " + input);
             }
 
             @Override

--- a/src/main/java/com/mojang/serialization/JsonOps.java
+++ b/src/main/java/com/mojang/serialization/JsonOps.java
@@ -88,14 +88,14 @@ public class JsonOps implements DynamicOps<JsonElement> {
                 try {
                     return DataResult.success(Integer.parseInt(input.getAsString()));
                 } catch (final NumberFormatException e) {
-                    return DataResult.error("Not a number: " + e + " " + input);
+                    return DataResult.error(() -> "Not a number: " + e + " " + input);
                 }
             }
         }
         if (input instanceof JsonPrimitive && input.getAsJsonPrimitive().isBoolean()) {
             return DataResult.success(input.getAsJsonPrimitive().getAsBoolean() ? 1 : 0);
         }
-        return DataResult.error("Not a number: " + input);
+        return DataResult.error(() -> "Not a number: " + input);
     }
 
     @Override
@@ -112,7 +112,7 @@ public class JsonOps implements DynamicOps<JsonElement> {
                 return DataResult.success(input.getAsNumber().byteValue() != 0);
             }
         }
-        return DataResult.error("Not a boolean: " + input);
+        return DataResult.error(() -> "Not a boolean: " + input);
     }
 
     @Override
@@ -127,7 +127,7 @@ public class JsonOps implements DynamicOps<JsonElement> {
                 return DataResult.success(input.getAsString());
             }
         }
-        return DataResult.error("Not a string: " + input);
+        return DataResult.error(() -> "Not a string: " + input);
     }
 
     @Override
@@ -138,7 +138,7 @@ public class JsonOps implements DynamicOps<JsonElement> {
     @Override
     public DataResult<JsonElement> mergeToList(final JsonElement list, final JsonElement value) {
         if (!(list instanceof JsonArray) && list != empty()) {
-            return DataResult.error("mergeToList called with not a list: " + list, list);
+            return DataResult.error(() -> "mergeToList called with not a list: " + list, list);
         }
 
         final JsonArray result = new JsonArray();
@@ -152,7 +152,7 @@ public class JsonOps implements DynamicOps<JsonElement> {
     @Override
     public DataResult<JsonElement> mergeToList(final JsonElement list, final List<JsonElement> values) {
         if (!(list instanceof JsonArray) && list != empty()) {
-            return DataResult.error("mergeToList called with not a list: " + list, list);
+            return DataResult.error(() -> "mergeToList called with not a list: " + list, list);
         }
 
         final JsonArray result = new JsonArray();
@@ -166,10 +166,10 @@ public class JsonOps implements DynamicOps<JsonElement> {
     @Override
     public DataResult<JsonElement> mergeToMap(final JsonElement map, final JsonElement key, final JsonElement value) {
         if (!(map instanceof JsonObject) && map != empty()) {
-            return DataResult.error("mergeToMap called with not a map: " + map, map);
+            return DataResult.error(() -> "mergeToMap called with not a map: " + map, map);
         }
         if (!(key instanceof JsonPrimitive) || !key.getAsJsonPrimitive().isString() && !compressed) {
-            return DataResult.error("key is not a string: " + key, map);
+            return DataResult.error(() -> "key is not a string: " + key, map);
         }
 
         final JsonObject output = new JsonObject();
@@ -184,7 +184,7 @@ public class JsonOps implements DynamicOps<JsonElement> {
     @Override
     public DataResult<JsonElement> mergeToMap(final JsonElement map, final MapLike<JsonElement> values) {
         if (!(map instanceof JsonObject) && map != empty()) {
-            return DataResult.error("mergeToMap called with not a map: " + map, map);
+            return DataResult.error(() -> "mergeToMap called with not a map: " + map, map);
         }
 
         final JsonObject output = new JsonObject();
@@ -204,7 +204,7 @@ public class JsonOps implements DynamicOps<JsonElement> {
         });
 
         if (!missed.isEmpty()) {
-            return DataResult.error("some keys are not strings: " + missed, output);
+            return DataResult.error(() -> "some keys are not strings: " + missed, output);
         }
 
         return DataResult.success(output);
@@ -213,7 +213,7 @@ public class JsonOps implements DynamicOps<JsonElement> {
     @Override
     public DataResult<Stream<Pair<JsonElement, JsonElement>>> getMapValues(final JsonElement input) {
         if (!(input instanceof JsonObject)) {
-            return DataResult.error("Not a JSON object: " + input);
+            return DataResult.error(() -> "Not a JSON object: " + input);
         }
         return DataResult.success(input.getAsJsonObject().entrySet().stream().map(entry -> Pair.of(new JsonPrimitive(entry.getKey()), entry.getValue() instanceof JsonNull ? null : entry.getValue())));
     }
@@ -221,7 +221,7 @@ public class JsonOps implements DynamicOps<JsonElement> {
     @Override
     public DataResult<Consumer<BiConsumer<JsonElement, JsonElement>>> getMapEntries(final JsonElement input) {
         if (!(input instanceof JsonObject)) {
-            return DataResult.error("Not a JSON object: " + input);
+            return DataResult.error(() -> "Not a JSON object: " + input);
         }
         return DataResult.success(c -> {
             for (final Map.Entry<String, JsonElement> entry : input.getAsJsonObject().entrySet()) {
@@ -233,7 +233,7 @@ public class JsonOps implements DynamicOps<JsonElement> {
     @Override
     public DataResult<MapLike<JsonElement>> getMap(final JsonElement input) {
         if (!(input instanceof JsonObject)) {
-            return DataResult.error("Not a JSON object: " + input);
+            return DataResult.error(() -> "Not a JSON object: " + input);
         }
         final JsonObject object = input.getAsJsonObject();
         return DataResult.success(new MapLike<JsonElement>() {
@@ -281,7 +281,7 @@ public class JsonOps implements DynamicOps<JsonElement> {
         if (input instanceof JsonArray) {
             return DataResult.success(StreamSupport.stream(input.getAsJsonArray().spliterator(), false).map(e -> e instanceof JsonNull ? null : e));
         }
-        return DataResult.error("Not a json array: " + input);
+        return DataResult.error(() -> "Not a json array: " + input);
     }
 
     @Override
@@ -293,7 +293,7 @@ public class JsonOps implements DynamicOps<JsonElement> {
                 }
             });
         }
-        return DataResult.error("Not a json array: " + input);
+        return DataResult.error(() -> "Not a json array: " + input);
     }
 
     @Override
@@ -365,7 +365,7 @@ public class JsonOps implements DynamicOps<JsonElement> {
         public DataResult<JsonElement> build(final JsonElement prefix) {
             final DataResult<JsonElement> result = builder.flatMap(b -> {
                 if (!(prefix instanceof JsonArray) && prefix != ops().empty()) {
-                    return DataResult.error("Cannot append a list to not a list: " + prefix, prefix);
+                    return DataResult.error(() -> "Cannot append a list to not a list: " + prefix, prefix);
                 }
 
                 final JsonArray array = new JsonArray();
@@ -422,7 +422,7 @@ public class JsonOps implements DynamicOps<JsonElement> {
                 }
                 return DataResult.success(result);
             }
-            return DataResult.error("mergeToMap called with not a map: " + prefix, prefix);
+            return DataResult.error(() -> "mergeToMap called with not a map: " + prefix, prefix);
         }
     }
 }

--- a/src/main/java/com/mojang/serialization/MapDecoder.java
+++ b/src/main/java/com/mojang/serialization/MapDecoder.java
@@ -21,7 +21,7 @@ public interface MapDecoder<A> extends Keyable {
             final Optional<Consumer<Consumer<T>>> inputList = ops.getList(input).result();
 
             if (!inputList.isPresent()) {
-                return DataResult.error("Input is not a list");
+                return DataResult.error(() -> "Input is not a list");
             }
 
             final KeyCompressor<T> compressor = compressor(ops);

--- a/src/main/java/com/mojang/serialization/codecs/FieldDecoder.java
+++ b/src/main/java/com/mojang/serialization/codecs/FieldDecoder.java
@@ -24,7 +24,7 @@ public final class FieldDecoder<A> extends MapDecoder.Implementation<A> {
     public <T> DataResult<A> decode(final DynamicOps<T> ops, final MapLike<T> input) {
         final T value = input.get(name);
         if (value == null) {
-            return DataResult.error("No key " + name + " in " + input);
+            return DataResult.error(() -> "No key " + name + " in " + input);
         }
         return elementCodec.parse(ops, value);
     }

--- a/src/main/java/com/mojang/serialization/codecs/KeyDispatchCodec.java
+++ b/src/main/java/com/mojang/serialization/codecs/KeyDispatchCodec.java
@@ -50,7 +50,7 @@ public class KeyDispatchCodec<K, V> extends MapCodec<V> {
     public <T> DataResult<V> decode(final DynamicOps<T> ops, final MapLike<T> input) {
         final T elementName = input.get(typeKey);
         if (elementName == null) {
-            return DataResult.error("Input does not contain a key [" + typeKey + "]: " + input);
+            return DataResult.error(() -> "Input does not contain a key [" + typeKey + "]: " + input);
         }
 
         return keyCodec.decode(ops, elementName).flatMap(type -> {
@@ -59,7 +59,7 @@ public class KeyDispatchCodec<K, V> extends MapCodec<V> {
                 if (ops.compressMaps()) {
                     final T value = input.get(ops.createString(valueKey));
                     if (value == null) {
-                        return DataResult.error("Input does not have a \"value\" entry: " + input);
+                        return DataResult.error(() -> "Input does not have a \"value\" entry: " + input);
                     }
                     return c.parse(ops, value).map(Function.identity());
                 }


### PR DESCRIPTION
Whenever the game is started up, DataFixerUpper builds and optimises functions that are able to upgrade data from every past data format to the most recent data format. Although the optimisation step comes at a high cost itself, it allows fixer functions, especially those that span many versions, to avoid unpacking/repacking data into intermediary structures when modifying deeply nested data many times. By building these at startup, this avoids latency during gameplay, but has a significant overhead during game launch. Although this process is extensively parallelised, it is one of the slowest parts of the game bootstrap process, and will only get slower with time as the data format continues to evolve.

This PR improves the performance of this process by addressing some easy-wins without changing any of the core logic for now.

Best reviewed commit-by-commit. Some commits have more in-depth explanations around specific changes.

## What is slow? Why is it slow?
While initially building the unoptimised functions is definitely a fairly time-consuming process, by far the cost of building datafixers comes from the optimisation step.
![image](https://user-images.githubusercontent.com/5172118/211612155-d22c60d3-bdbc-4970-8a52-3e0d610ccd4a.png)

In basic: the optimisation process works by applying various rules that restructure the produced datafixing functions based on the algebraic rules given by the point-free style of functions. Many of these rules are applied one-at-a-time (`many(once(...))` rule), where a single node in the point-free tree is rewritten before packing up the new modified tree. This particularly means that the same logic runs many, many times on the same data. The changes in this PR generally focus around reducing that additional traversal, as well as generally improving the performance of making that traversal.

~~The main change in this regard, and the highest-impact change in this PR, involves caching for individual branches of the tree when a given rule no longer applies. This avoids traversing already 'stable' parts of the tree.~~ This change is superseded by the change to no longer use the `once()` rule at all in #72.

Garbage collection is another aspect of this: the point-free optimisation step particularly generates a lot of short-lived objects that create high amounts of GC pressure.

|![image](https://user-images.githubusercontent.com/5172118/211606843-5a66e913-7d6f-4fd7-8f5f-b78666588dca.png)|![image](https://user-images.githubusercontent.com/5172118/211606624-c50e42ac-eacf-4bd9-96e9-41df321d3e2d.png)|
|-|-|

The majority these allocations come from the recursive point-free rewrite rules, which are flattened in this PR, as well as `Optional` usage and single-value types that were recreated for each use.

## Fixer application
While this PR mainly focuses on the bootstrap process, the last few commits also make a change for performance when applying fixers. A large amount of time spent in fixer application is spent calling `.toString()` on NBT data. This is due to the use of `Codec` and `DataResult`: when an error is encountered, the `DataResult` type can hold an error string to represent its failure. Most often, these errors include the stringified data that failed to be parsed. This wouldn't be a concern, because that data is needed to display the error, but these error strings are most often entirely discarded. This is, for example, frequently encountered through the `EitherCodec` which chooses one result and discards the error of the other if it fails.

## Results
From testing, these changes provide roughly a 7x improvement in datafixer bootstrap time, which is consistent both when running on a single thread as well as in parallel:

|Before|After|
|-|-|
|![image](https://user-images.githubusercontent.com/5172118/211610833-232eb2e2-7566-417f-8d0b-41b9a8f49083.png)|![image](https://user-images.githubusercontent.com/5172118/211609562-bad45afc-54ec-4785-8e49-9a38f360677b.png)|
|Average 35s in parallel, 136s on a single thread|Average 5s in parallel, 15s on a single thread|

For fixer application, the `DataResult` changes provide roughly a 1.8x improvement (before: 56s, after: 30s) to optimise a 1.6.4 world

