### PR TITLE
Data fixer performance - flatten composition and restructure optimisation rule

### DIFF
--- a/src/main/java/com/mojang/datafixers/DataFixerUpper.java
+++ b/src/main/java/com/mojang/datafixers/DataFixerUpper.java
@@ -50,8 +50,7 @@ public class DataFixerUpper implements DataFixer {
             ),
             PointFreeRule.LensAppId.INSTANCE,
             PointFreeRule.LensComp.INSTANCE,
-            PointFreeRule.AppNest.INSTANCE,
-            PointFreeRule.LensCompFunc.INSTANCE
+            PointFreeRule.AppNest.INSTANCE
         );
         final PointFreeRule opLeft = PointFreeRule.many(PointFreeRule.once(PointFreeRule.choice(opSimple, PointFreeRule.CompAssocLeft.INSTANCE)));
         final PointFreeRule opComp = PointFreeRule.many(PointFreeRule.once(PointFreeRule.CompRewrite.choice(PointFreeRule.SortInj.INSTANCE, PointFreeRule.SortProj.INSTANCE)));

--- a/src/main/java/com/mojang/datafixers/DataFixerUpper.java
+++ b/src/main/java/com/mojang/datafixers/DataFixerUpper.java
@@ -44,15 +44,17 @@ public class DataFixerUpper implements DataFixer {
 
     protected static final PointFreeRule OPTIMIZATION_RULE = DataFixUtils.make(() -> {
         final PointFreeRule opSimple = PointFreeRule.choice(
-            PointFreeRule.CataFuseSame.INSTANCE,
-            PointFreeRule.CataFuseDifferent.INSTANCE,
+            PointFreeRule.CompRewrite.choice(
+                PointFreeRule.CataFuseSame.INSTANCE,
+                PointFreeRule.CataFuseDifferent.INSTANCE
+            ),
             PointFreeRule.LensAppId.INSTANCE,
             PointFreeRule.LensComp.INSTANCE,
             PointFreeRule.AppNest.INSTANCE,
             PointFreeRule.LensCompFunc.INSTANCE
         );
         final PointFreeRule opLeft = PointFreeRule.many(PointFreeRule.once(PointFreeRule.choice(opSimple, PointFreeRule.CompAssocLeft.INSTANCE)));
-        final PointFreeRule opComp = PointFreeRule.many(PointFreeRule.once(PointFreeRule.choice(PointFreeRule.SortInj.INSTANCE, PointFreeRule.SortProj.INSTANCE)));
+        final PointFreeRule opComp = PointFreeRule.many(PointFreeRule.once(PointFreeRule.CompRewrite.choice(PointFreeRule.SortInj.INSTANCE, PointFreeRule.SortProj.INSTANCE)));
         final PointFreeRule opRight = PointFreeRule.many(PointFreeRule.once(PointFreeRule.choice(opSimple, PointFreeRule.CompAssocRight.INSTANCE)));
         return PointFreeRule.seq(opLeft, opComp, opRight, opLeft, opRight);
     });

--- a/src/main/java/com/mojang/datafixers/functions/Apply.java
+++ b/src/main/java/com/mojang/datafixers/functions/Apply.java
@@ -42,11 +42,12 @@ final class Apply<A, B> extends PointFree<B> {
 
     @Override
     public Optional<? extends PointFree<B>> all(final PointFreeRule rule) {
-        return Optional.of(new Apply<>(
-            rule.rewrite(func).map(f1 -> (PointFree<Function<A, B>>) f1).orElse(func),
-            rule.rewrite(arg).map(f -> (PointFree<A>) f).orElse(arg),
-            type
-        ));
+        final PointFree<Function<A, B>> f = rule.rewriteOrNop(func);
+        final PointFree<A> a = rule.rewriteOrNop(arg);
+        if (f == func && a == arg) {
+            return Optional.of(this);
+        }
+        return Optional.of(new Apply<>(f, a, type));
     }
 
     @Override

--- a/src/main/java/com/mojang/datafixers/functions/Bang.java
+++ b/src/main/java/com/mojang/datafixers/functions/Bang.java
@@ -28,12 +28,12 @@ final class Bang<A> extends PointFree<Function<A, Unit>> {
 
     @Override
     public boolean equals(final Object o) {
-        return o instanceof Bang<?>;
+        return o instanceof Bang<?> bang && type.equals(bang.type);
     }
 
     @Override
     public int hashCode() {
-        return Bang.class.hashCode();
+        return type.hashCode();
     }
 
     @Override

--- a/src/main/java/com/mojang/datafixers/functions/Bang.java
+++ b/src/main/java/com/mojang/datafixers/functions/Bang.java
@@ -2,13 +2,23 @@
 // Licensed under the MIT license.
 package com.mojang.datafixers.functions;
 
+import com.mojang.datafixers.DSL;
+import com.mojang.datafixers.types.Type;
 import com.mojang.datafixers.util.Unit;
 import com.mojang.serialization.DynamicOps;
 
 import java.util.function.Function;
 
 final class Bang<A> extends PointFree<Function<A, Unit>> {
-    Bang() {
+    private final Type<A> type;
+
+    Bang(final Type<A> type) {
+        this.type = type;
+    }
+
+    @Override
+    public Type<Function<A, Unit>> type() {
+        return DSL.func(type, DSL.emptyPartType());
     }
 
     @Override

--- a/src/main/java/com/mojang/datafixers/functions/Bang.java
+++ b/src/main/java/com/mojang/datafixers/functions/Bang.java
@@ -2,11 +2,12 @@
 // Licensed under the MIT license.
 package com.mojang.datafixers.functions;
 
+import com.mojang.datafixers.util.Unit;
 import com.mojang.serialization.DynamicOps;
 
 import java.util.function.Function;
 
-final class Bang<A> extends PointFree<Function<A, Void>> {
+final class Bang<A> extends PointFree<Function<A, Unit>> {
     Bang() {
     }
 
@@ -26,7 +27,7 @@ final class Bang<A> extends PointFree<Function<A, Void>> {
     }
 
     @Override
-    public Function<DynamicOps<?>, Function<A, Void>> eval() {
-        return ops -> a -> null;
+    public Function<DynamicOps<?>, Function<A, Unit>> eval() {
+        return ops -> a -> Unit.INSTANCE;
     }
 }

--- a/src/main/java/com/mojang/datafixers/functions/Comp.java
+++ b/src/main/java/com/mojang/datafixers/functions/Comp.java
@@ -41,11 +41,12 @@ final class Comp<A, B, C> extends PointFree<Function<A, C>> {
 
     @Override
     public Optional<? extends PointFree<Function<A, C>>> all(final PointFreeRule rule) {
-        return Optional.of(new Comp<>(
-            rule.rewrite(first).map(f -> (PointFree<Function<B, C>>) f).orElse(first),
-            rule.rewrite(second).map(f1 -> (PointFree<Function<A, B>>) f1).orElse(second),
-            type
-        ));
+        final PointFree<Function<B, C>> f = rule.rewriteOrNop(first);
+        final PointFree<Function<A, B>> s = rule.rewriteOrNop(second);
+        if (f == first && s == second) {
+            return Optional.of(this);
+        }
+        return Optional.of(new Comp<>(f, s, type));
     }
 
     @Override

--- a/src/main/java/com/mojang/datafixers/functions/Fold.java
+++ b/src/main/java/com/mojang/datafixers/functions/Fold.java
@@ -74,12 +74,13 @@ final class Fold<A, B> extends PointFree<Function<A, B>> {
             return false;
         }
         final Fold<?, ?> fold = (Fold<?, ?>) o;
-        return Objects.equals(aType, fold.aType) && Objects.equals(algebra, fold.algebra);
+        return Objects.equals(aType, fold.aType) && Objects.equals(bType, fold.bType) && Objects.equals(algebra, fold.algebra);
     }
 
     @Override
     public int hashCode() {
         int result = aType.hashCode();
+        result = 31 * result + bType.hashCode();
         result = 31 * result + algebra.hashCode();
         return result;
     }

--- a/src/main/java/com/mojang/datafixers/functions/Fold.java
+++ b/src/main/java/com/mojang/datafixers/functions/Fold.java
@@ -3,8 +3,10 @@
 package com.mojang.datafixers.functions;
 
 import com.google.common.collect.Maps;
+import com.mojang.datafixers.DSL;
 import com.mojang.datafixers.RewriteResult;
 import com.mojang.datafixers.View;
+import com.mojang.datafixers.types.Type;
 import com.mojang.datafixers.types.families.Algebra;
 import com.mojang.datafixers.types.families.RecursiveTypeFamily;
 import com.mojang.datafixers.types.templates.RecursivePoint;
@@ -35,8 +37,13 @@ final class Fold<A, B> extends PointFree<Function<A, B>> {
         this.index = index;
     }
 
+    @Override
+    public Type<Function<A, B>> type() {
+        return DSL.func(aType, bType);
+    }
+
     private <FB> PointFree<Function<A, B>> cap(final RewriteResult<?, B> op, final RewriteResult<?, FB> resResult) {
-        return Functions.comp(resResult.view().newType(), ((View<FB, B>) op.view()).function(), ((View<A, FB>) resResult.view()).function());
+        return Functions.comp(((View<FB, B>) op.view()).function(), ((View<A, FB>) resResult.view()).function());
     }
 
     @Override

--- a/src/main/java/com/mojang/datafixers/functions/FunctionWrapper.java
+++ b/src/main/java/com/mojang/datafixers/functions/FunctionWrapper.java
@@ -2,6 +2,8 @@
 // Licensed under the MIT license.
 package com.mojang.datafixers.functions;
 
+import com.mojang.datafixers.DSL;
+import com.mojang.datafixers.types.Type;
 import com.mojang.serialization.DynamicOps;
 
 import java.util.Objects;
@@ -10,10 +12,17 @@ import java.util.function.Function;
 final class FunctionWrapper<A, B> extends PointFree<Function<A, B>> {
     private final String name;
     protected final Function<DynamicOps<?>, Function<A, B>> fun;
+    private final Type<Function<A, B>> type;
 
-    FunctionWrapper(final String name, final Function<DynamicOps<?>, Function<A, B>> fun) {
+    FunctionWrapper(final String name, final Function<DynamicOps<?>, Function<A, B>> fun, final Type<A> input, final Type<B> output) {
         this.name = name;
         this.fun = fun;
+        type = DSL.func(input, output);
+    }
+
+    @Override
+    public Type<Function<A, B>> type() {
+        return type;
     }
 
     @Override

--- a/src/main/java/com/mojang/datafixers/functions/FunctionWrapper.java
+++ b/src/main/java/com/mojang/datafixers/functions/FunctionWrapper.java
@@ -39,7 +39,7 @@ final class FunctionWrapper<A, B> extends PointFree<Function<A, B>> {
             return false;
         }
         final FunctionWrapper<?, ?> that = (FunctionWrapper<?, ?>) o;
-        return Objects.equals(fun, that.fun);
+        return Objects.equals(fun, that.fun) && Objects.equals(type, that.type);
     }
 
     @Override

--- a/src/main/java/com/mojang/datafixers/functions/Functions.java
+++ b/src/main/java/com/mojang/datafixers/functions/Functions.java
@@ -22,6 +22,22 @@ public abstract class Functions {
         if (Functions.isId(f2)) {
             return (PointFree<Function<A, C>>) (PointFree<?>) f1;
         }
+        if (f1 instanceof Comp<B, C> comp1 && f2 instanceof Comp<A, B> comp2) {
+            final PointFree<? extends Function<?, ?>>[] functions = new PointFree[comp1.functions.length + comp2.functions.length];
+            System.arraycopy(comp1.functions, 0, functions, 0, comp1.functions.length);
+            System.arraycopy(comp2.functions, 0, functions, comp1.functions.length, comp2.functions.length);
+            return new Comp<>(functions);
+        } else if (f1 instanceof Comp<B, C> comp1) {
+            final PointFree<? extends Function<?, ?>>[] functions = new PointFree[comp1.functions.length + 1];
+            System.arraycopy(comp1.functions, 0, functions, 0, comp1.functions.length);
+            functions[functions.length - 1] = f2;
+            return new Comp<>(functions);
+        } else if (f2 instanceof Comp<A, B> comp2) {
+            final PointFree<? extends Function<?, ?>>[] functions = new PointFree[1 + comp2.functions.length];
+            functions[0] = f1;
+            System.arraycopy(comp2.functions, 0, functions, 1, comp2.functions.length);
+            return new Comp<>(functions);
+        }
         return new Comp<>(f1, f2);
     }
 

--- a/src/main/java/com/mojang/datafixers/functions/Functions.java
+++ b/src/main/java/com/mojang/datafixers/functions/Functions.java
@@ -2,44 +2,43 @@
 // Licensed under the MIT license.
 package com.mojang.datafixers.functions;
 
+import com.mojang.datafixers.DSL;
 import com.mojang.datafixers.FunctionType;
 import com.mojang.datafixers.RewriteResult;
 import com.mojang.datafixers.optics.Optic;
-import com.mojang.datafixers.types.Func;
 import com.mojang.datafixers.types.Type;
 import com.mojang.datafixers.types.families.Algebra;
 import com.mojang.datafixers.types.templates.RecursivePoint;
 import com.mojang.serialization.DynamicOps;
 
-import java.util.Objects;
 import java.util.function.Function;
 
 public abstract class Functions {
     @SuppressWarnings("unchecked")
-    public static <A, B, C> PointFree<Function<A, C>> comp(final Type<B> middleType, final PointFree<Function<B, C>> f1, final PointFree<Function<A, B>> f2) {
+    public static <A, B, C> PointFree<Function<A, C>> comp(final PointFree<Function<B, C>> f1, final PointFree<Function<A, B>> f2) {
         if (Functions.isId(f1)) {
             return (PointFree<Function<A, C>>) (PointFree<?>) f2;
         }
         if (Functions.isId(f2)) {
             return (PointFree<Function<A, C>>) (PointFree<?>) f1;
         }
-        return new Comp<>(middleType, f1, f2);
+        return new Comp<>(f1, f2);
     }
 
-    public static <A, B> PointFree<Function<A, B>> fun(final String name, final Function<DynamicOps<?>, Function<A, B>> fun) {
-        return new FunctionWrapper<>(name, fun);
+    public static <A, B> PointFree<Function<A, B>> fun(final String name, final Function<DynamicOps<?>, Function<A, B>> fun, final Type<A> input, final Type<B> output) {
+        return new FunctionWrapper<>(name, fun, input, output);
     }
 
-    public static <A, B> PointFree<B> app(final PointFree<Function<A, B>> fun, final PointFree<A> arg, final Type<A> argType) {
-        return new Apply<>(fun, arg, argType);
+    public static <A, B> PointFree<B> app(final PointFree<Function<A, B>> fun, final PointFree<A> arg) {
+        return new Apply<>(fun, arg);
     }
 
-    public static <S, T, A, B> PointFree<Function<Function<A, B>, Function<S, T>>> profunctorTransformer(final Optic<? super FunctionType.Instance.Mu, S, T, A, B> lens) {
-        return new ProfunctorTransformer<>(lens);
+    public static <S, T, A, B> PointFree<Function<Function<A, B>, Function<S, T>>> profunctorTransformer(final Optic<? super FunctionType.Instance.Mu, S, T, A, B> lens, final Type<Function<Function<A, B>, Function<S, T>>> type) {
+        return new ProfunctorTransformer<>(lens, type);
     }
 
-    public static <A> Bang<A> bang() {
-        return new Bang<>();
+    public static <A> Bang<A> bang(final Type<A> type) {
+        return new Bang<>(type);
     }
 
     public static <A> PointFree<Function<A, A>> in(final RecursivePoint.RecursivePointType<A> type) {
@@ -54,8 +53,8 @@ public abstract class Functions {
         return new Fold<>(aType, bType, function, algebra, index);
     }
 
-    public static <A> PointFree<Function<A, A>> id() {
-        return new Id<>();
+    public static <A> PointFree<Function<A, A>> id(final Type<A> type) {
+        return new Id<>(DSL.func(type, type));
     }
 
     public static boolean isId(final PointFree<?> function) {

--- a/src/main/java/com/mojang/datafixers/functions/Functions.java
+++ b/src/main/java/com/mojang/datafixers/functions/Functions.java
@@ -50,8 +50,8 @@ public abstract class Functions {
         return new Out<>(type);
     }
 
-    public static <A, B> PointFree<Function<A, B>> fold(final RecursivePoint.RecursivePointType<A> aType, final RewriteResult<?, B> function, final Algebra algebra, final int index) {
-        return new Fold<>(aType, function, algebra, index);
+    public static <A, B> PointFree<Function<A, B>> fold(final RecursivePoint.RecursivePointType<A> aType, final RecursivePoint.RecursivePointType<B> bType, final RewriteResult<A, B> function, final Algebra algebra, final int index) {
+        return new Fold<>(aType, bType, function, algebra, index);
     }
 
     public static <A> PointFree<Function<A, A>> id() {

--- a/src/main/java/com/mojang/datafixers/functions/Functions.java
+++ b/src/main/java/com/mojang/datafixers/functions/Functions.java
@@ -54,12 +54,11 @@ public abstract class Functions {
         return new Fold<>(aType, function, algebra, index);
     }
 
-    @SuppressWarnings("unchecked")
     public static <A> PointFree<Function<A, A>> id() {
-        return (Id<A>) Id.INSTANCE;
+        return new Id<>();
     }
 
     public static boolean isId(final PointFree<?> function) {
-        return function == Id.INSTANCE;
+        return function instanceof Id<?>;
     }
 }

--- a/src/main/java/com/mojang/datafixers/functions/Id.java
+++ b/src/main/java/com/mojang/datafixers/functions/Id.java
@@ -7,9 +7,12 @@ import com.mojang.serialization.DynamicOps;
 import java.util.function.Function;
 
 final class Id<A> extends PointFree<Function<A, A>> {
-    public static final Id<?> INSTANCE = new Id<>();
+    Id() {
+    }
 
-    private Id() {
+    @Override
+    public boolean equals(final Object obj) {
+        return obj instanceof Id<?>;
     }
 
     @Override

--- a/src/main/java/com/mojang/datafixers/functions/Id.java
+++ b/src/main/java/com/mojang/datafixers/functions/Id.java
@@ -21,12 +21,12 @@ final class Id<A> extends PointFree<Function<A, A>> {
 
     @Override
     public boolean equals(final Object obj) {
-        return obj instanceof Id<?>;
+        return obj instanceof Id<?> id && type.equals(id.type);
     }
 
     @Override
     public int hashCode() {
-        return Id.class.hashCode();
+        return type.hashCode();
     }
 
     @Override

--- a/src/main/java/com/mojang/datafixers/functions/Id.java
+++ b/src/main/java/com/mojang/datafixers/functions/Id.java
@@ -2,12 +2,21 @@
 // Licensed under the MIT license.
 package com.mojang.datafixers.functions;
 
+import com.mojang.datafixers.types.Type;
 import com.mojang.serialization.DynamicOps;
 
 import java.util.function.Function;
 
 final class Id<A> extends PointFree<Function<A, A>> {
-    Id() {
+    private final Type<Function<A, A>> type;
+
+    Id(final Type<Function<A, A>> type) {
+        this.type = type;
+    }
+
+    @Override
+    public Type<Function<A, A>> type() {
+        return type;
     }
 
     @Override

--- a/src/main/java/com/mojang/datafixers/functions/In.java
+++ b/src/main/java/com/mojang/datafixers/functions/In.java
@@ -2,6 +2,8 @@
 // Licensed under the MIT license.
 package com.mojang.datafixers.functions;
 
+import com.mojang.datafixers.DSL;
+import com.mojang.datafixers.types.Type;
 import com.mojang.datafixers.types.templates.RecursivePoint;
 import com.mojang.serialization.DynamicOps;
 
@@ -13,6 +15,11 @@ final class In<A> extends PointFree<Function<A, A>> {
 
     public In(final RecursivePoint.RecursivePointType<A> type) {
         this.type = type;
+    }
+
+    @Override
+    public Type<Function<A, A>> type() {
+        return DSL.func(type.unfold(), type);
     }
 
     @Override

--- a/src/main/java/com/mojang/datafixers/functions/Out.java
+++ b/src/main/java/com/mojang/datafixers/functions/Out.java
@@ -2,6 +2,8 @@
 // Licensed under the MIT license.
 package com.mojang.datafixers.functions;
 
+import com.mojang.datafixers.DSL;
+import com.mojang.datafixers.types.Type;
 import com.mojang.datafixers.types.templates.RecursivePoint;
 import com.mojang.serialization.DynamicOps;
 
@@ -13,6 +15,11 @@ final class Out<A> extends PointFree<Function<A, A>> {
 
     public Out(final RecursivePoint.RecursivePointType<A> type) {
         this.type = type;
+    }
+
+    @Override
+    public Type<Function<A, A>> type() {
+        return DSL.func(type, type.unfold());
     }
 
     @Override

--- a/src/main/java/com/mojang/datafixers/functions/PointFree.java
+++ b/src/main/java/com/mojang/datafixers/functions/PointFree.java
@@ -28,13 +28,15 @@ public abstract class PointFree<T> {
         return value;
     }
 
+    public abstract Type<T> type();
+
     public abstract Function<DynamicOps<?>, T> eval();
 
-    Optional<? extends PointFree<T>> all(final PointFreeRule rule, final Type<T> type) {
+    Optional<? extends PointFree<T>> all(final PointFreeRule rule) {
         return Optional.of(this);
     }
 
-    Optional<? extends PointFree<T>> one(final PointFreeRule rule, final Type<T> type) {
+    Optional<? extends PointFree<T>> one(final PointFreeRule rule) {
         return Optional.empty();
     }
 

--- a/src/main/java/com/mojang/datafixers/functions/PointFreeRule.java
+++ b/src/main/java/com/mojang/datafixers/functions/PointFreeRule.java
@@ -218,7 +218,7 @@ public interface PointFreeRule {
             return (PointFree<E>) new Comp<>(comp2.middleType, comp2.first, new Comp<>(comp1.middleType, comp2.second, comp1.second));
         }
 
-        Optional<? extends PointFree<?>> doRewrite(PointFree<? extends Function<?, ?>> first, PointFree<? extends Function<?, ?>> second);
+        Optional<? extends PointFree<? extends Function<?, ?>>> doRewrite(PointFree<? extends Function<?, ?>> first, PointFree<? extends Function<?, ?>> second);
     }
 
     enum SortProj implements CompRewrite {
@@ -226,7 +226,7 @@ public interface PointFreeRule {
 
         // (ap π1 f)◦(ap π2 g) -> (ap π2 g)◦(ap π1 f)
         @Override
-        public Optional<? extends PointFree<?>> doRewrite(final PointFree<? extends Function<?, ?>> first, final PointFree<? extends Function<?, ?>> second) {
+        public Optional<? extends PointFree<? extends Function<?, ?>>> doRewrite(final PointFree<? extends Function<?, ?>> first, final PointFree<? extends Function<?, ?>> second) {
             if (first instanceof Apply<?, ?> && second instanceof Apply<?, ?>) {
                 final Apply<?, ?> applyFirst = (Apply<?, ?>) first;
                 final Apply<?, ?> applySecond = (Apply<?, ?>) second;
@@ -275,7 +275,7 @@ public interface PointFreeRule {
 
         // (ap i1 f)◦(ap i2 g) -> (ap i2 g)◦(ap i1 f)
         @Override
-        public Optional<? extends PointFree<?>> doRewrite(final PointFree<? extends Function<?, ?>> first, final PointFree<? extends Function<?, ?>> second) {
+        public Optional<? extends PointFree<? extends Function<?, ?>>> doRewrite(final PointFree<? extends Function<?, ?>> first, final PointFree<? extends Function<?, ?>> second) {
             if (first instanceof Apply<?, ?> && second instanceof Apply<?, ?>) {
                 final Apply<?, ?> applyFirst = (Apply<?, ?>) first;
                 final Apply<?, ?> applySecond = (Apply<?, ?>) second;
@@ -351,7 +351,7 @@ public interface PointFreeRule {
         // (ap lens f)◦(ap lens g) -> (ap lens (f ◦ g))
         @SuppressWarnings("unchecked")
         @Override
-        public Optional<? extends PointFree<?>> doRewrite(final PointFree<? extends Function<?, ?>> first, final PointFree<? extends Function<?, ?>> second) {
+        public Optional<? extends PointFree<? extends Function<?, ?>>> doRewrite(final PointFree<? extends Function<?, ?>> first, final PointFree<? extends Function<?, ?>> second) {
           if (first instanceof Apply<?, ?> && second instanceof Apply<?, ?>) {
                 final Apply<?, ?> applyFirst = (Apply<?, ?>) first;
                 final Apply<?, ?> applySecond = (Apply<?, ?>) second;
@@ -388,7 +388,7 @@ public interface PointFreeRule {
         // (fold g ◦ in) ◦ fold (f ◦ in) -> fold ( g ◦ f ◦ in), <== g ◦ in ◦ fold (f ◦ in) ◦ out == in ◦ fold (f ◦ in) ◦ out ◦ g <== g doesn't touch fold's index
         @SuppressWarnings("unchecked")
         @Override
-        public Optional<? extends PointFree<?>> doRewrite(final PointFree<? extends Function<?, ?>> first, final PointFree<? extends Function<?, ?>> second) {
+        public Optional<? extends PointFree<? extends Function<?, ?>>> doRewrite(final PointFree<? extends Function<?, ?>> first, final PointFree<? extends Function<?, ?>> second) {
             if (first instanceof Fold<?, ?> && second instanceof Fold<?, ?>) {
                 // fold (_) ◦ fold (_)
                 final Fold<?, ?> firstFold = (Fold<?, ?>) first;
@@ -435,7 +435,7 @@ public interface PointFreeRule {
         // (fold g ◦ in) ◦ fold (f ◦ in) -> fold ( g ◦ f ◦ in), <== g ◦ in ◦ fold (f ◦ in) ◦ out == in ◦ fold (f ◦ in) ◦ out ◦ g <== g doesn't touch fold's index
         @SuppressWarnings("unchecked")
         @Override
-        public Optional<? extends PointFree<?>> doRewrite(final PointFree<? extends Function<?, ?>> first, final PointFree<? extends Function<?, ?>> second) {
+        public Optional<? extends PointFree<? extends Function<?, ?>>> doRewrite(final PointFree<? extends Function<?, ?>> first, final PointFree<? extends Function<?, ?>> second) {
             if (first instanceof Fold<?, ?> && second instanceof Fold<?, ?>) {
                 // fold (_) ◦ fold (_)
                 final Fold<?, ?> firstFold = (Fold<?, ?>) first;

--- a/src/main/java/com/mojang/datafixers/functions/PointFreeRule.java
+++ b/src/main/java/com/mojang/datafixers/functions/PointFreeRule.java
@@ -527,14 +527,11 @@ public interface PointFreeRule {
     record Seq(PointFreeRule[] rules) implements PointFreeRule {
         @Override
         public <A> Optional<? extends PointFree<A>> rewrite(final PointFree<A> expr) {
-            Optional<? extends PointFree<A>> result = Optional.of(expr);
+            PointFree<A> result = expr;
             for (final PointFreeRule rule : rules) {
-                result = rule.rewrite(result.get());
-                if (result.isEmpty()) {
-                    return Optional.empty();
-                }
+                result = rule.rewriteOrNop(result);
             }
-            return result;
+            return Optional.of(result);
         }
 
         @Override

--- a/src/main/java/com/mojang/datafixers/functions/PointFreeRule.java
+++ b/src/main/java/com/mojang/datafixers/functions/PointFreeRule.java
@@ -162,6 +162,18 @@ public interface PointFreeRule {
     }
 
     interface CompRewrite extends PointFreeRule {
+        static CompRewrite choice(final CompRewrite... rules) {
+            return (first, second) -> {
+                for (final CompRewrite rule : rules) {
+                    final Optional<? extends PointFree<? extends Function<?, ?>>> view = rule.doRewrite(first, second);
+                    if (view.isPresent()) {
+                        return view;
+                    }
+                }
+                return Optional.empty();
+            };
+        }
+
         @Override
         default <A> Optional<? extends PointFree<A>> rewrite(final Type<A> type, final PointFree<A> expr) {
             if (expr instanceof Comp<?, ?, ?>) {

--- a/src/main/java/com/mojang/datafixers/functions/PointFreeRule.java
+++ b/src/main/java/com/mojang/datafixers/functions/PointFreeRule.java
@@ -31,16 +31,8 @@ import java.util.function.Supplier;
 public interface PointFreeRule {
     <A> Optional<? extends PointFree<A>> rewrite(final Type<A> type, final PointFree<A> expr);
 
-    default <A, B> Optional<View<A, B>> rewrite(final View<A, B> view) {
-        return rewrite(view.funcType(), view.function()).map(pf -> View.create(view.type(), view.newType(), pf));
-    }
-
     default <A> PointFree<A> rewriteOrNop(final Type<A> type, final PointFree<A> expr) {
         return DataFixUtils.orElse(rewrite(type, expr), expr);
-    }
-
-    default <A, B> View<A, B> rewriteOrNop(final View<A, B> view) {
-        return DataFixUtils.orElse(rewrite(view), view);
     }
 
     static PointFreeRule nop() {

--- a/src/main/java/com/mojang/datafixers/functions/PointFreeRule.java
+++ b/src/main/java/com/mojang/datafixers/functions/PointFreeRule.java
@@ -409,6 +409,7 @@ public interface PointFreeRule {
                 final Fold<?, ?> secondFold = (Fold<?, ?>) second;
                 final RecursiveTypeFamily family = firstFold.aType.family();
                 if (firstFold.index == secondFold.index && Objects.equals(family, secondFold.aType.family())) {
+                    final RecursiveTypeFamily newFamily = firstFold.bType.family();
                     // same fold
                     final List<RewriteResult<?, ?>> newAlgebra = Lists.newArrayList();
 
@@ -431,7 +432,7 @@ public interface PointFreeRule {
                         }
                     }
                     final Algebra algebra = new ListAlgebra("FusedSame", newAlgebra);
-                    return Optional.of(family.fold(algebra).apply(firstFold.index).view().function());
+                    return Optional.of(family.fold(algebra, newFamily).apply(firstFold.index).view().function());
                 }
             }
             return Optional.empty();
@@ -456,6 +457,7 @@ public interface PointFreeRule {
                 final Fold<?, ?> secondFold = (Fold<?, ?>) second;
                 final RecursiveTypeFamily family = firstFold.aType.family();
                 if (firstFold.index == secondFold.index && Objects.equals(family, secondFold.aType.family())) {
+                    final RecursiveTypeFamily newFamily = firstFold.bType.family();
                     // same fold
                     final List<RewriteResult<?, ?>> newAlgebra = Lists.newArrayList();
 
@@ -492,7 +494,7 @@ public interface PointFreeRule {
                     // have new algebra - make a new fold
 
                     final Algebra algebra = new ListAlgebra("FusedDifferent", newAlgebra);
-                    return Optional.of(family.fold(algebra).apply(firstFold.index).view().function());
+                    return Optional.of(family.fold(algebra, newFamily).apply(firstFold.index).view().function());
                 }
             }
             return Optional.empty();

--- a/src/main/java/com/mojang/datafixers/functions/PointFreeRule.java
+++ b/src/main/java/com/mojang/datafixers/functions/PointFreeRule.java
@@ -643,15 +643,17 @@ public interface PointFreeRule {
         return new Many(rule);
     }
 
-    static PointFreeRule everywhere(final PointFreeRule rule) {
-        return new Everywhere(rule);
+    static PointFreeRule everywhere(final PointFreeRule topDown, final PointFreeRule bottomUp) {
+        return new Everywhere(topDown, bottomUp);
     }
 
-    record Everywhere(PointFreeRule rule) implements PointFreeRule {
+    record Everywhere(PointFreeRule topDown, PointFreeRule bottomUp) implements PointFreeRule {
         @Override
         public <A> Optional<? extends PointFree<A>> rewrite(final PointFree<A> expr) {
-            final PointFree<A> view = rule.rewriteOrNop(expr);
-            return view.all(this);
+            final PointFree<A> topDown = this.topDown.rewriteOrNop(expr);
+            final PointFree<A> all = DataFixUtils.orElse(topDown.all(this), topDown);
+            final PointFree<A> bottomUp = this.bottomUp.rewriteOrNop(all);
+            return Optional.of(bottomUp);
         }
     }
 

--- a/src/main/java/com/mojang/datafixers/functions/PointFreeRule.java
+++ b/src/main/java/com/mojang/datafixers/functions/PointFreeRule.java
@@ -275,6 +275,7 @@ public interface PointFreeRule {
         @SuppressWarnings("unchecked")
         private <R, A, A2, B, B2> R cap(final Func<B, B2> firstArg, final Func<A, A2> secondArg, final Apply<?, ?> first, final Apply<?, ?> second) {
             return (R) Functions.comp(
+                // Bug: this middle type is technically incorrect for nested optics, but it is never used
                 DSL.and(secondArg.first(), firstArg.second()),
                 (PointFree<Function<Pair<A, B2>, Pair<A2, B2>>>) second,
                 (PointFree<Function<Pair<A, B>, Pair<A, B2>>>) first
@@ -324,6 +325,7 @@ public interface PointFreeRule {
         @SuppressWarnings("unchecked")
         private <R, A, A2, B, B2> R cap(final Func<B, B2> firstArg, final Func<A, A2> secondArg, final Apply<?, ?> first, final Apply<?, ?> second) {
             return (R) Functions.comp(
+                // Bug: this middle type is technically incorrect for nested optics, but it is never used
                 DSL.or(secondArg.first(), firstArg.second()),
                 (PointFree<Function<Either<A, B2>, Either<A2, B2>>>) second,
                 (PointFree<Function<Either<A, B>, Either<A, B2>>>) first

--- a/src/main/java/com/mojang/datafixers/functions/ProfunctorTransformer.java
+++ b/src/main/java/com/mojang/datafixers/functions/ProfunctorTransformer.java
@@ -5,6 +5,7 @@ package com.mojang.datafixers.functions;
 import com.mojang.datafixers.FunctionType;
 import com.mojang.datafixers.kinds.App2;
 import com.mojang.datafixers.optics.Optic;
+import com.mojang.datafixers.types.Type;
 import com.mojang.serialization.DynamicOps;
 
 import java.util.Objects;
@@ -12,9 +13,21 @@ import java.util.function.Function;
 
 final class ProfunctorTransformer<S, T, A, B> extends PointFree<Function<Function<A, B>, Function<S, T>>> {
     protected final Optic<? super FunctionType.Instance.Mu, S, T, A, B> optic;
+    protected final Type<Function<Function<A, B>, Function<S, T>>> type;
 
-    public ProfunctorTransformer(final Optic<? super FunctionType.Instance.Mu, S, T, A, B> optic) {
+    public ProfunctorTransformer(final Optic<? super FunctionType.Instance.Mu, S, T, A, B> optic, final Type<Function<Function<A, B>, Function<S, T>>> type) {
         this.optic = optic;
+        this.type = type;
+    }
+
+    @SuppressWarnings("unchecked")
+    public <S2, T2> ProfunctorTransformer<S2, T2, A, B> castOuterUnchecked(final Type<Function<Function<A, B>, Function<S2, T2>>> newType) {
+        return new ProfunctorTransformer<>((Optic<? super FunctionType.Instance.Mu, S2, T2, A, B>) optic, newType);
+    }
+
+    @Override
+    public Type<Function<Function<A, B>, Function<S, T>>> type() {
+        return type;
     }
 
     @Override

--- a/src/main/java/com/mojang/datafixers/functions/ProfunctorTransformer.java
+++ b/src/main/java/com/mojang/datafixers/functions/ProfunctorTransformer.java
@@ -51,7 +51,7 @@ final class ProfunctorTransformer<S, T, A, B> extends PointFree<Function<Functio
             return false;
         }
         final ProfunctorTransformer<?, ?, ?, ?> that = (ProfunctorTransformer<?, ?, ?, ?>) o;
-        return Objects.equals(optic, that.optic);
+        return Objects.equals(optic, that.optic) && Objects.equals(type, that.type);
     }
 
     @Override

--- a/src/main/java/com/mojang/datafixers/functions/ProfunctorTransformer.java
+++ b/src/main/java/com/mojang/datafixers/functions/ProfunctorTransformer.java
@@ -12,13 +12,9 @@ import java.util.function.Function;
 
 final class ProfunctorTransformer<S, T, A, B> extends PointFree<Function<Function<A, B>, Function<S, T>>> {
     protected final Optic<? super FunctionType.Instance.Mu, S, T, A, B> optic;
-    protected final Function<App2<FunctionType.Mu, A, B>, App2<FunctionType.Mu, S, T>> func;
-    private final Function<Function<A, B>, Function<S, T>> unwrappedFunction;
 
     public ProfunctorTransformer(final Optic<? super FunctionType.Instance.Mu, S, T, A, B> optic) {
         this.optic = optic;
-        func = optic.eval(FunctionType.Instance.INSTANCE);
-        unwrappedFunction = input -> FunctionType.unbox(func.apply(FunctionType.create(input)));
     }
 
     @Override
@@ -28,6 +24,8 @@ final class ProfunctorTransformer<S, T, A, B> extends PointFree<Function<Functio
 
     @Override
     public Function<DynamicOps<?>, Function<Function<A, B>, Function<S, T>>> eval() {
+        final Function<App2<FunctionType.Mu, A, B>, App2<FunctionType.Mu, S, T>> func = optic.eval(FunctionType.Instance.INSTANCE);
+        final Function<Function<A, B>, Function<S, T>> unwrappedFunction = input -> FunctionType.unbox(func.apply(FunctionType.create(input)));
         return ops -> unwrappedFunction;
     }
 

--- a/src/main/java/com/mojang/datafixers/optics/Optic.java
+++ b/src/main/java/com/mojang/datafixers/optics/Optic.java
@@ -17,12 +17,17 @@ public interface Optic<Proof extends K1, S, T, A, B> {
     <P extends K2> Function<App2<P, A, B>, App2<P, S, T>> eval(final App<? extends Proof, P> proof);
 
     default <Proof2 extends Proof, A1, B1> Optic<Proof2, S, T, A1, B1> compose(final Optic<? super Proof2, A, B, A1, B1> optic) {
-        return new CompositionOptic<>(this, optic);
+        return composeUnchecked(optic);
     }
 
     @SuppressWarnings("unchecked")
-    default <Proof2 extends K1, A1, B1> Optic<?, S, T, A1, B1> composeUnchecked(final Optic<?, A, B, A1, B1> optic) {
-        return new CompositionOptic<Proof2, S, T, A, B, A1, B1>((Optic<? super Proof2, S, T, A, B>) this, (Optic<? super Proof2, A, B, A1, B1>) optic);
+    default <Proof2 extends K1, A1, B1> Optic<Proof2, S, T, A1, B1> composeUnchecked(final Optic<?, A, B, A1, B1> optic) {
+        if (Optics.isId(optic)) {
+            return (Optic<Proof2, S, T, A1, B1>) this;
+        } else if (Optics.isId(this)) {
+            return (Optic<Proof2, S, T, A1, B1>) optic;
+        }
+        return new CompositionOptic<>((Optic<? super Proof2, S, T, A, B>) this, (Optic<? super Proof2, A, B, A1, B1>) optic);
     }
 
     record CompositionOptic<Proof extends K1, S, T, A, B, A1, B1>(Optic<? super Proof, S, T, A, B> outer, Optic<? super Proof, A, B, A1, B1> inner) implements Optic<Proof, S, T, A1, B1> {

--- a/src/main/java/com/mojang/datafixers/optics/Optics.java
+++ b/src/main/java/com/mojang/datafixers/optics/Optics.java
@@ -69,6 +69,10 @@ public abstract class Optics {
         return (Adapter<S, T, S, T>) IdAdapter.INSTANCE;
     }
 
+    public static boolean isId(final Optic<?, ?, ?, ?, ?> optic) {
+        return optic == IdAdapter.INSTANCE;
+    }
+
     public static <S, T, A, B> Adapter<S, T, A, B> adapter(final Function<S, A> from, final Function<B, T> to) {
         return new Adapter<S, T, A, B>() {
             @Override

--- a/src/main/java/com/mojang/datafixers/types/Type.java
+++ b/src/main/java/com/mojang/datafixers/types/Type.java
@@ -61,12 +61,15 @@ public abstract class Type<A> implements App<Type.Mu, A> {
         }
         // copy the recData, since optic doesn't touch more than the nested view
         return RewriteResult.create(View.create(
-            optic.sType(),
-            optic.tType(),
             Functions.app(
-                Functions.profunctorTransformer(optic.upCast(FunctionType.Instance.Mu.TYPE_TOKEN).orElseThrow(IllegalArgumentException::new)),
-                view.view().function(),
-                DSL.func(optic.aType(), view.view().newType())
+                Functions.profunctorTransformer(
+                    optic.upCast(FunctionType.Instance.Mu.TYPE_TOKEN).orElseThrow(IllegalArgumentException::new),
+                    DSL.func(
+                        DSL.func(optic.aType(), view.view().newType()),
+                        DSL.func(optic.sType(), optic.tType())
+                    )
+                ),
+                view.view().function()
             )), view.recData());
     }
 

--- a/src/main/java/com/mojang/datafixers/types/families/RecursiveTypeFamily.java
+++ b/src/main/java/com/mojang/datafixers/types/families/RecursiveTypeFamily.java
@@ -50,11 +50,6 @@ public final class RecursiveTypeFamily implements TypeFamily {
     }
 
     @SuppressWarnings("unchecked")
-    public static <A, B> View<A, B> viewUnchecked(final Type<?> type, final Type<?> resType, final PointFree<Function<A, B>> function) {
-        return View.create((Type<A>) type, (Type<B>) resType, function);
-    }
-
-    @SuppressWarnings("unchecked")
     public <A> RecursivePoint.RecursivePointType<A> buildMuType(final Type<A> newType, @Nullable RecursiveTypeFamily newFamily) {
         if (newFamily == null) {
             // G
@@ -101,7 +96,7 @@ public final class RecursiveTypeFamily implements TypeFamily {
         return index -> {
             final RewriteResult<?, ?> result = algebra.apply(index);
             // FIXME: is this corrext?
-            return RewriteResult.create(viewUnchecked(result.view().type(), result.view().newType(), foldUnchecked(this, newFamily, algebra, index, result)), result.recData());
+            return RewriteResult.create(View.create(foldUnchecked(this, newFamily, algebra, index, result)), result.recData());
         };
     }
 
@@ -185,7 +180,7 @@ public final class RecursiveTypeFamily implements TypeFamily {
         }
         final Algebra algebra = new ListAlgebra("everywhere", views);
         final RewriteResult<?, ?> fold = fold(algebra, newFamily).apply(index);
-        return Optional.of(RewriteResult.create(viewUnchecked(apply(index), newType, fold.view().function()), fold.recData()));
+        return Optional.of(RewriteResult.create(View.create(fold.view().function()), fold.recData()));
     }
 
     private <A, B> boolean cap2(final List<RewriteResult<?, ?>> views, final RecursivePoint.RecursivePointType<A> type, final TypeRewriteRule rule, final PointFreeRule optimizationRule, boolean nop, RewriteResult<?, ?> view, final RecursivePoint.RecursivePointType<B> newType) {

--- a/src/main/java/com/mojang/datafixers/types/families/RecursiveTypeFamily.java
+++ b/src/main/java/com/mojang/datafixers/types/families/RecursiveTypeFamily.java
@@ -60,7 +60,7 @@ public final class RecursiveTypeFamily implements TypeFamily {
             // G
             final TypeTemplate newTypeTemplate = newType.template();
             // Mu G
-            if (template == newTypeTemplate) {
+            if (Objects.equals(template, newTypeTemplate)) {
                 newFamily = this;
             } else {
                 newFamily = new RecursiveTypeFamily("ruled " + name, newTypeTemplate);

--- a/src/main/java/com/mojang/datafixers/types/templates/Product.java
+++ b/src/main/java/com/mojang/datafixers/types/templates/Product.java
@@ -166,6 +166,14 @@ public final class Product implements TypeTemplate {
             this.second = second;
         }
 
+        public Type<F> first() {
+            return first;
+        }
+
+        public Type<G> second() {
+            return second;
+        }
+
         @Override
         public RewriteResult<Pair<F, G>, ?> all(final TypeRewriteRule rule, final boolean recurse, final boolean checkIndex) {
             return mergeViews(first.rewriteOrNop(rule), second.rewriteOrNop(rule));

--- a/src/main/java/com/mojang/datafixers/types/templates/RecursivePoint.java
+++ b/src/main/java/com/mojang/datafixers/types/templates/RecursivePoint.java
@@ -75,20 +75,17 @@ public final class RecursivePoint implements TypeTemplate {
         };
     }
 
-    @SuppressWarnings("unchecked")
     public <S, T> RewriteResult<S, T> cap(final TypeFamily family, final RewriteResult<S, T> result) {
         final Type<?> sourceType = family.apply(index);
         if (!(sourceType instanceof RecursivePointType<?>)) {
             throw new IllegalArgumentException("Type error: Recursive point template template got a non-recursice type as an input.");
         }
-        if (!Objects.equals(result.view().type(), ((RecursivePointType<?>) sourceType).unfold())) {
+        if (!Objects.equals(result.view().type(), sourceType)) {
             throw new IllegalArgumentException("Type error: hmap function input type");
         }
-        final RecursivePointType<S> sType = (RecursivePointType<S>) sourceType;
-        final RecursivePointType<T> tType = sType.family().buildMuType(result.view().newType(), null);
         final BitSet bitSet = ObjectUtils.clone(result.recData());
         bitSet.set(index);
-        return RewriteResult.create(View.create(sType, tType, result.view().function()), bitSet);
+        return RewriteResult.create(result.view(), bitSet);
     }
 
     @Override
@@ -282,11 +279,11 @@ public final class RecursivePoint implements TypeTemplate {
         }
 
         public View<A, A> in() {
-            return View.create(unfold(), this, Functions.in(this));
+            return View.create(Functions.in(this));
         }
 
         public View<A, A> out() {
-            return View.create(this, unfold(), Functions.out(this));
+            return View.create(Functions.out(this));
         }
     }
 }

--- a/src/main/java/com/mojang/datafixers/types/templates/Sum.java
+++ b/src/main/java/com/mojang/datafixers/types/templates/Sum.java
@@ -165,6 +165,14 @@ public final class Sum implements TypeTemplate {
             this.second = second;
         }
 
+        public Type<F> first() {
+            return first;
+        }
+
+        public Type<G> second() {
+            return second;
+        }
+
         @Override
         public RewriteResult<Either<F, G>, ?> all(final TypeRewriteRule rule, final boolean recurse, final boolean checkIndex) {
             return mergeViews(first.rewriteOrNop(rule), second.rewriteOrNop(rule));

--- a/src/main/java/com/mojang/datafixers/types/templates/TaggedChoice.java
+++ b/src/main/java/com/mojang/datafixers/types/templates/TaggedChoice.java
@@ -162,7 +162,7 @@ public final class TaggedChoice<K> implements TypeTemplate {
                 newTypes.put(entry.getKey(), entry.getValue().view().newType());
                 recData.or(entry.getValue().recData());
             }
-            return RewriteResult.create(View.create(this, DSL.taggedChoiceType(name, keyType, newTypes), Functions.fun("TaggedChoiceTypeRewriteResult " + results.size(), new RewriteFunc<>(results))), recData);
+            return RewriteResult.create(View.create(Functions.fun("TaggedChoiceTypeRewriteResult " + results.size(), new RewriteFunc<>(results), this, DSL.taggedChoiceType(name, keyType, newTypes))), recData);
         }
 
         public static <K, FT, FR> RewriteResult<Pair<K, ?>, Pair<K, ?>> elementResult(final K key, final TaggedChoiceType<K> type, final RewriteResult<FT, FR> result) {


### PR DESCRIPTION
Follow-up to #71 with the "not easy bits" - the more structural / logic changes. 

To copy words from #71:
> In basic: the optimisation process works by applying various rules that restructure the produced datafixing functions based on the algebraic rules given by the point-free style of functions. Many of these rules are applied one-at-a-time (`many(once(...))` rule), where a single node in the point-free tree is rewritten before packing up the new modified tree. This particularly means that the same logic runs many, many times on the same data.

Although the previous PR made changes that improved the performance of rewriting with the `once()` rule, this PR replaces those entirely with a new optimisation rule that applies every rule within a single traversal of the tree. To do this, this PR flattens point-free function compositions into a linear array instead trees of nested compositions. This removes the need for the association rewriting rules, which took up a large portion of time themselves. Additionally, due to how they restructured the tree, it was infeasible to apply rewrites "all at once" to the same degree as is done here.

Flattening composition is enabled/made easier by a change to encode `Type` information in each `PointFree` instance directly, instead of only encoding intermediate types. This means `PointFreeRule` no longer needs to accept a `Type`. There is some weird behaviour with creating `View` instances: some types generate `View`s with different types to the underlying function. This is used in cases such as tagged fields, which need to tag the final type such that the overall `View` can construct a correct `Codec`.

## Results
With the latest changes to #71, I measure an average of 8s to build fixers on a single thread. With this PR, the average time is ~1.2s. 

The majority of this time is now spent building the initial fixer function, as opposed to optimisation:
![image](https://user-images.githubusercontent.com/5172118/212956037-585330a9-427f-460a-b737-9daa60104f4e.png)