### PR TITLE
Fix: resolve message when calling toString() on PartialResult

### DIFF
--- a/src/main/java/com/mojang/serialization/DataResult.java
+++ b/src/main/java/com/mojang/serialization/DataResult.java
@@ -275,7 +275,7 @@ public class DataResult<R> implements App<DataResult.Mu, R> {
 
         @Override
         public String toString() {
-            return "DynamicException[" + message + ' ' + partialResult + ']';
+            return "DynamicException[" + message() + ' ' + partialResult + ']';
         }
     }
 


### PR DESCRIPTION
When making DataResult error message resolution lazy in #71, the `PartialResult.toString()` implementation was not updated to resolve the message. This causes lambda strings to appear in error messages (e.g. [MC-260617](https://bugs.mojang.com/browse/MC-260617))