### PR TITLE
Delegate `MapCodecCodec` map functions to `MapCodec` map functions

### DIFF
--- a/src/main/java/com/mojang/serialization/MapCodec.java
+++ b/src/main/java/com/mojang/serialization/MapCodec.java
@@ -97,6 +97,28 @@ public abstract class MapCodec<A> extends CompressorHolder implements MapDecoder
         }
 
         @Override
+        @SuppressWarnings("unchecked")
+        public <S> Codec<S> xmap(final Function<? super A, ? extends S> to, final Function<? super S, ? extends A> from) {
+            return (Codec<S>) codec.xmap(to, from).codec();
+        }
+
+        @Override
+        public <S> Codec<S> comapFlatMap(final Function<? super A, ? extends DataResult<? extends S>> to, final Function<? super S, ? extends A> from) {
+            return codec.comapFlatMap(to, from).codec();
+        }
+
+        @Override
+        @SuppressWarnings("unchecked")
+        public <S> Codec<S> flatComapMap(Function<? super A, ? extends S> to, Function<? super S, ? extends DataResult<? extends A>> from) {
+            return (Codec<S>) codec.flatComapMap(to, from).codec();
+        }
+
+        @Override
+        public <S> Codec<S> flatXmap(Function<? super A, ? extends DataResult<? extends S>> to, Function<? super S, ? extends DataResult<? extends A>> from) {
+            return codec.flatXmap(to, from).codec();
+        }
+
+        @Override
         public String toString() {
             return codec.toString();
         }
@@ -116,6 +138,14 @@ public abstract class MapCodec<A> extends CompressorHolder implements MapDecoder
 
     public <S> MapCodec<S> xmap(final Function<? super A, ? extends S> to, final Function<? super S, ? extends A> from) {
         return MapCodec.of(comap(from), map(to), () -> toString() + "[xmapped]");
+    }
+
+    public <S> MapCodec<S> comapFlatMap(final Function<? super A, ? extends DataResult<? extends S>> to, final Function<? super S, ? extends A> from) {
+        return MapCodec.of(comap(from), flatMap(to), () -> toString() + "[comapFlatMapped]");
+    }
+
+    public <S> MapCodec<S> flatComapMap(final Function<? super A, ? extends S> to, final Function<? super S, ? extends DataResult<? extends A>> from) {
+        return MapCodec.of(flatComap(from), map(to), () -> toString() + "[flatComapMapped]");
     }
 
     public <S> MapCodec<S> flatXmap(final Function<? super A, ? extends DataResult<? extends S>> to, final Function<? super S, ? extends DataResult<? extends A>> from) {


### PR DESCRIPTION
```java
Codec<A> codecA = RecordCodecBuilder.create(/*...*/);
Codec<B> codecB = codecA.xmap(/*...*/);
```

Calling `Codec#dispatch` with `B` as one of the possible value will results a codec for the following JSON:
```jsonc
{
  "type": "b",
  "value": {
    // values from a
  }
}
```
Instead of this, which is what it results if `A` is used directly.
```jsonc
{
  "type": "b",
  // values from a
}
```
This happens because `KeyDispatchCodec` has a special case for `MapCodecCodec`, but the default `Codec#xmap` returns a `Codec`.

https://github.com/Mojang/DataFixerUpper/blob/6d0d1e6281abd94328b135b53f3f3b592dc9f6cd/src/main/java/com/mojang/serialization/codecs/KeyDispatchCodec.java#L66-L68
https://github.com/Mojang/DataFixerUpper/blob/6d0d1e6281abd94328b135b53f3f3b592dc9f6cd/src/main/java/com/mojang/serialization/codecs/KeyDispatchCodec.java#L91-L94

Overriding the map functions on `MapCodecCodec` to use the `MapCodec` map fixes this issue as it will return the correct type.