### PR TITLE
Fix: don't fail entire rewrite if recursive type did not match anywhere at top-level

### DIFF
--- a/src/main/java/com/mojang/datafixers/types/templates/RecursivePoint.java
+++ b/src/main/java/com/mojang/datafixers/types/templates/RecursivePoint.java
@@ -146,7 +146,10 @@ public record RecursivePoint(int index) implements TypeTemplate {
         @Override
         public Optional<RewriteResult<A, ?>> everywhere(final TypeRewriteRule rule, final PointFreeRule optimizationRule, final boolean recurse, final boolean checkIndex) {
             if (recurse) {
-                return family.everywhere(this.index, rule, optimizationRule).map(view -> (RewriteResult<A, ?>) view);
+                final Optional<RewriteResult<A, ?>> result = family.everywhere(this.index, rule, optimizationRule).map(view -> (RewriteResult<A, ?>) view);
+                if (result.isPresent()) {
+                    return result;
+                }
             }
             return Optional.of(RewriteResult.nop(this));
         }


### PR DESCRIPTION
Usually, rewrites to recursive types are deeply nested - which will cause any failure to fallback to no-op (through most `Type.all()` implementations). The semantics of `everywhere` are similar to `all` - if nothing can be rewritten internally, that is not an error state.

This will cause no fixer function to be produced if a top-level recursive type has a fixer defined within a version range, but that type does not exist within the type being fixed.

Doesn't currently impact Vanilla, but became a bit more likely with 1a8eb415198a72c612163ad6c25505b57a891adb.
