### PR TITLE
Handle dispatch codec receiving null decoders more gracefully

### DIFF
--- a/src/main/java/com/mojang/serialization/Codec.java
+++ b/src/main/java/com/mojang/serialization/Codec.java
@@ -326,11 +326,23 @@ public interface Codec<A> extends Encoder<A>, Decoder<A> {
     }
 
     default <E> Codec<E> dispatch(final String typeKey, final Function<? super E, ? extends A> type, final Function<? super A, ? extends Codec<? extends E>> codec) {
-        return partialDispatch(typeKey, type.andThen(DataResult::success), codec.andThen(DataResult::success));
+        return partialDispatch(typeKey, type.andThen(DataResult::success), key -> {
+            final Codec<? extends E> result = codec.apply(key);
+            if (result != null) {
+                return DataResult.success(result);
+            }
+            return DataResult.error(() -> "No codec found for key: " + key);
+        });
     }
 
     default <E> Codec<E> dispatchStable(final Function<? super E, ? extends A> type, final Function<? super A, ? extends Codec<? extends E>> codec) {
-        return partialDispatch("type", e -> DataResult.success(type.apply(e), Lifecycle.stable()), a -> DataResult.success(codec.apply(a), Lifecycle.stable()));
+        return partialDispatch("type", e -> DataResult.success(type.apply(e), Lifecycle.stable()), key -> {
+            final Codec<? extends E> result = codec.apply(key);
+            if (result != null) {
+                return DataResult.success(result, Lifecycle.stable());
+            }
+            return DataResult.error(() -> "No codec found for key: " + key, Lifecycle.stable());
+        });
     }
 
     default <E> Codec<E> partialDispatch(final String typeKey, final Function<? super E, ? extends DataResult<? extends A>> type, final Function<? super A, ? extends DataResult<? extends Codec<? extends E>>> codec) {
@@ -342,7 +354,13 @@ public interface Codec<A> extends Encoder<A>, Decoder<A> {
     }
 
     default <E> MapCodec<E> dispatchMap(final String typeKey, final Function<? super E, ? extends A> type, final Function<? super A, ? extends Codec<? extends E>> codec) {
-        return new KeyDispatchCodec<>(typeKey, this, type.andThen(DataResult::success), codec.andThen(DataResult::success));
+        return new KeyDispatchCodec<>(typeKey, this, type.andThen(DataResult::success), (key) -> {
+            final Codec<? extends E> result = codec.apply(key);
+            if (result != null) {
+                return DataResult.success(result);
+            }
+            return DataResult.error(() -> "No map codec found for key: " + key);
+        });
     }
 
     // private

--- a/src/main/java/com/mojang/serialization/codecs/KeyDispatchCodec.java
+++ b/src/main/java/com/mojang/serialization/codecs/KeyDispatchCodec.java
@@ -54,8 +54,12 @@ public class KeyDispatchCodec<K, V> extends MapCodec<V> {
         }
 
         return keyCodec.decode(ops, elementName).flatMap(type -> {
-            final DataResult<? extends Decoder<? extends V>> elementDecoder = decoder.apply(type.getFirst());
+            final K key = type.getFirst();
+            final DataResult<? extends Decoder<? extends V>> elementDecoder = decoder.apply(key);
             return elementDecoder.flatMap(c -> {
+                if (c == null) {
+                    return DataResult.error(() -> "Decoder returned null for \"" + key + "\" in " + input);
+                }
                 if (ops.compressMaps()) {
                     final T value = input.get(ops.createString(valueKey));
                     if (value == null) {


### PR DESCRIPTION
The KeyDispatchCodec assumes that a decoder can never be null when received as such it causes an npe when trying to use it. This PR changes it so that the dispatch methods on the Codec class now check if the Codec returned is null and returns an appropriate DataResult error and the decoder call in KeyDispatchCodec gives a generic DataResult error