### PR TITLE
Add basic module support via manifest attribute.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -60,6 +60,14 @@ sourceSets {
     }
 }
 
+jar {
+    manifest {
+        attributes(
+            'Automatic-Module-Name': 'com.mojang.dfu'
+        )
+    }
+}
+
 artifacts {
     archives jar
     archives sourcesJar


### PR DESCRIPTION
This PR adds the manifest attribute `Automatic-Module-Name` to allow projects that use Jigsaw modules to correctly identify this project no matter what the jar itself is called.

The Jar spec has some more details: https://docs.oracle.com/en/java/javase/21/docs/specs/jar/jar.html