### PR TITLE
Handle `null` input in `JsonOps.convertTo`

### DIFF
--- a/src/main/java/com/mojang/serialization/JsonOps.java
+++ b/src/main/java/com/mojang/serialization/JsonOps.java
@@ -44,7 +44,7 @@ public class JsonOps implements DynamicOps<JsonElement> {
         if (input instanceof JsonArray) {
             return convertList(outOps, input);
         }
-        if (input instanceof JsonNull) {
+        if (input instanceof JsonNull || input == null) {
             return outOps.empty();
         }
         final JsonPrimitive primitive = input.getAsJsonPrimitive();


### PR DESCRIPTION
The current implementation of `JsonOps.convertTo` throws a null pointer exception when `input` is `null` by calling `input.getAsJsonPrimitive()` without checking for `null`. Instead, the implementation only checks whether `input` is an implementation of `JsonNull`. This is problematic because some of the other methods in `JsonOps` replace a `JsonNull` instance with `null` when returning it, which makes it possible that `input` is `null` instead of a `JsonNull` instance. An example of such a method is `JsonOps.getMapValues`.

This is an issue with the implementation of `convertTo` and not just a problem with call sites elsewhere, because `convertTo` also uses `getMapValues` when converting maps and it recursively calls `convertTo` on the returned map values, which means an input like `{"value": null}` is also going to throw an error even though it is a valid `JsonObject` instance.

This pull request adds a null check besides the `instanceof` check for `JsonNull`, such that a `null` input value and a value of type `JsonNull` are handled the same in `JsonOps.convertTo`.

This also fixes #62