### PR TITLE
Fix RecordCodecs not maintaining field order

### DIFF
--- a/src/main/java/com/mojang/serialization/codecs/RecordCodecBuilder.java
+++ b/src/main/java/com/mojang/serialization/codecs/RecordCodecBuilder.java
@@ -160,8 +160,8 @@ public final class RecordCodecBuilder<O, F> implements App<RecordCodecBuilder.Mu
                         return new MapEncoder.Implementation<R>() {
                             @Override
                             public <T> RecordBuilder<T> encode(final R input, final DynamicOps<T> ops, final RecordBuilder<T> prefix) {
-                                aEnc.encode(aFromO, ops, prefix);
                                 fEnc.encode(a1 -> input, ops, prefix);
+                                aEnc.encode(aFromO, ops, prefix);
                                 return prefix;
                             }
 
@@ -219,9 +219,9 @@ public final class RecordCodecBuilder<O, F> implements App<RecordCodecBuilder.Mu
                     return new MapEncoder.Implementation<R>() {
                         @Override
                         public <T> RecordBuilder<T> encode(final R input, final DynamicOps<T> ops, final RecordBuilder<T> prefix) {
+                            fEncoder.encode((a1, b1) -> input, ops, prefix);
                             aEncoder.encode(aFromO, ops, prefix);
                             bEncoder.encode(bFromO, ops, prefix);
-                            fEncoder.encode((a1, b1) -> input, ops, prefix);
                             return prefix;
                         }
 
@@ -292,10 +292,10 @@ public final class RecordCodecBuilder<O, F> implements App<RecordCodecBuilder.Mu
                     return new MapEncoder.Implementation<R>() {
                         @Override
                         public <T> RecordBuilder<T> encode(final R input, final DynamicOps<T> ops, final RecordBuilder<T> prefix) {
+                            fEncoder.encode((t1, t2, t3) -> input, ops, prefix);
                             e1.encode(v1, ops, prefix);
                             e2.encode(v2, ops, prefix);
                             e3.encode(v3, ops, prefix);
-                            fEncoder.encode((t1, t2, t3) -> input, ops, prefix);
                             return prefix;
                         }
 
@@ -373,11 +373,11 @@ public final class RecordCodecBuilder<O, F> implements App<RecordCodecBuilder.Mu
                     return new MapEncoder.Implementation<R>() {
                         @Override
                         public <T> RecordBuilder<T> encode(final R input, final DynamicOps<T> ops, final RecordBuilder<T> prefix) {
+                            fEncoder.encode((t1, t2, t3, t4) -> input, ops, prefix);
                             e1.encode(v1, ops, prefix);
                             e2.encode(v2, ops, prefix);
                             e3.encode(v3, ops, prefix);
                             e4.encode(v4, ops, prefix);
-                            fEncoder.encode((t1, t2, t3, t4) -> input, ops, prefix);
                             return prefix;
                         }
 

--- a/src/test/java/com/mojang/serialization/CodecTests.java
+++ b/src/test/java/com/mojang/serialization/CodecTests.java
@@ -803,7 +803,7 @@ public class CodecTests {
     @Test
     public void recordCodec_maintainFieldOrder() {
         assertMapOrderEqual(
-            Map.of(
+            ImmutableMap.of(
                 "f1", 5,
                 "f2", 4,
                 "f3", 3,
@@ -814,7 +814,7 @@ public class CodecTests {
         );
 
         assertMapOrderEqual(
-            Map.of(
+            ImmutableMap.of(
                 "f1", 7,
                 "f2", 6,
                 "f3", 5,

--- a/src/test/java/com/mojang/serialization/CodecTests.java
+++ b/src/test/java/com/mojang/serialization/CodecTests.java
@@ -769,4 +769,61 @@ public class CodecTests {
         assertFromJavaFails(codec, 123);
         assertToJavaFails(codec, 123);
     }
+
+    private record RecordWith5Fields(int f1, int f2, int f3, int f4, int f5) {
+        public static final Codec<RecordWith5Fields> CODEC = RecordCodecBuilder.create(i -> i.group(
+            Codec.INT.fieldOf("f1").forGetter(RecordWith5Fields::f1),
+            Codec.INT.fieldOf("f2").forGetter(RecordWith5Fields::f2),
+            Codec.INT.fieldOf("f3").forGetter(RecordWith5Fields::f3),
+            Codec.INT.fieldOf("f4").forGetter(RecordWith5Fields::f4),
+            Codec.INT.fieldOf("f5").forGetter(RecordWith5Fields::f5)
+        ).apply(i, RecordWith5Fields::new));
+    }
+
+    private record RecordWith7Fields(int f1, int f2, int f3, int f4, int f5, int f6, int f7) {
+        public static final Codec<RecordWith7Fields> CODEC = RecordCodecBuilder.create(i -> i.group(
+            Codec.INT.fieldOf("f1").forGetter(RecordWith7Fields::f1),
+            Codec.INT.fieldOf("f2").forGetter(RecordWith7Fields::f2),
+            Codec.INT.fieldOf("f3").forGetter(RecordWith7Fields::f3),
+            Codec.INT.fieldOf("f4").forGetter(RecordWith7Fields::f4),
+            Codec.INT.fieldOf("f5").forGetter(RecordWith7Fields::f5),
+            Codec.INT.fieldOf("f6").forGetter(RecordWith7Fields::f6),
+            Codec.INT.fieldOf("f7").forGetter(RecordWith7Fields::f7)
+        ).apply(i, RecordWith7Fields::new));
+    }
+
+    private static void assertMapOrderEqual(Map<?, ?> expected, Object actual) {
+        assertTrue(actual instanceof Map<?, ?>);
+        assertEquals(
+            new ArrayList<>(expected.entrySet()),
+            new ArrayList<>(((Map<?, ?>) actual).entrySet())
+        );
+    }
+
+    @Test
+    public void recordCodec_maintainFieldOrder() {
+        assertMapOrderEqual(
+            Map.of(
+                "f1", 5,
+                "f2", 4,
+                "f3", 3,
+                "f4", 2,
+                "f5", 1
+            ),
+            toJava(RecordWith5Fields.CODEC, new RecordWith5Fields(5, 4, 3, 2, 1))
+        );
+
+        assertMapOrderEqual(
+            Map.of(
+                "f1", 7,
+                "f2", 6,
+                "f3", 5,
+                "f4", 4,
+                "f5", 3,
+                "f6", 2,
+                "f7", 1
+            ),
+            toJava(RecordWith7Fields.CODEC, new RecordWith7Fields(7, 6, 5, 4, 3, 2, 1))
+        );
+    }
 }


### PR DESCRIPTION
This PR fixes the issue outlined in #101.

The issue is caused by `com.mojang.serialization.codecs.RecordCodecBuilder$Instance`, specifically the `MapEncoders` provided by the overiden methods `lift1`, `ap2`, `ap3`, `ap4`, the order of operations is incorrect which results in the fields of record codecs being incorrectly ordered.

This is only true for the encoders, the decoding is done in the correct order.